### PR TITLE
fix redactSecrets stack overflow on circular references

### DIFF
--- a/packages/runtimeuse/src/utils.test.ts
+++ b/packages/runtimeuse/src/utils.test.ts
@@ -116,5 +116,15 @@ describe("redactSecrets", () => {
         redactSecrets("my-secret-key", ["secret", "my-secret-key"]),
       ).toBe("my-[REDACTED]-key");
     });
+
+    it("handles circular references without stack overflow", () => {
+      const obj: Record<string, unknown> = { key: "SECRET" };
+      obj.self = obj;
+      const result = redactSecrets(obj, ["SECRET"]) as Record<string, unknown>;
+      expect(result.key).toBe("[REDACTED]");
+      // Circular ref points to the redacted result, not the original
+      expect(result.self).toBe(result);
+      expect((result.self as Record<string, unknown>).key).toBe("[REDACTED]");
+    });
   });
 });

--- a/packages/runtimeuse/src/utils.ts
+++ b/packages/runtimeuse/src/utils.ts
@@ -6,39 +6,44 @@ export async function sleep(ms: number) {
  * Recursively redact secret values from an arbitrary data structure.
  * Any string that contains a secret will have that secret replaced with [REDACTED].
  */
-export function redactSecrets<T>(value: T, secrets: string[], seen?: WeakMap<object, unknown>): T {
+export function redactSecrets<T>(value: T, secrets: string[]): T {
   if (secrets.length === 0) return value;
 
-  if (typeof value === "string") {
-    let redacted: string = value;
-    for (const secret of secrets) {
-      if (secret && redacted.includes(secret)) {
-        redacted = redacted.replaceAll(secret, "[REDACTED]");
+  const seen = new WeakMap<object, unknown>();
+
+  function redact<U>(val: U): U {
+    if (typeof val === "string") {
+      let redacted: string = val;
+      for (const secret of secrets) {
+        if (secret && redacted.includes(secret)) {
+          redacted = redacted.replaceAll(secret, "[REDACTED]");
+        }
       }
+      return redacted as U;
     }
-    return redacted as T;
+
+    if (val !== null && typeof val === "object") {
+      if (seen.has(val as object)) return seen.get(val as object) as U;
+
+      if (Array.isArray(val)) {
+        const result: unknown[] = [];
+        seen.set(val as object, result);
+        for (const item of val) {
+          result.push(redact(item));
+        }
+        return result as U;
+      }
+
+      const result: Record<string, unknown> = {};
+      seen.set(val as object, result);
+      for (const [key, v] of Object.entries(val)) {
+        result[key] = redact(v);
+      }
+      return result as U;
+    }
+
+    return val;
   }
 
-  if (value !== null && typeof value === "object") {
-    if (!seen) seen = new WeakMap();
-    if (seen.has(value as object)) return seen.get(value as object) as T;
-
-    if (Array.isArray(value)) {
-      const result: unknown[] = [];
-      seen.set(value as object, result);
-      for (const item of value) {
-        result.push(redactSecrets(item, secrets, seen));
-      }
-      return result as T;
-    }
-
-    const result: Record<string, unknown> = {};
-    seen.set(value as object, result);
-    for (const [key, val] of Object.entries(value)) {
-      result[key] = redactSecrets(val, secrets, seen);
-    }
-    return result as T;
-  }
-
-  return value;
+  return redact(value);
 }

--- a/packages/runtimeuse/src/utils.ts
+++ b/packages/runtimeuse/src/utils.ts
@@ -6,7 +6,7 @@ export async function sleep(ms: number) {
  * Recursively redact secret values from an arbitrary data structure.
  * Any string that contains a secret will have that secret replaced with [REDACTED].
  */
-export function redactSecrets<T>(value: T, secrets: string[]): T {
+export function redactSecrets<T>(value: T, secrets: string[], seen?: WeakMap<object, unknown>): T {
   if (secrets.length === 0) return value;
 
   if (typeof value === "string") {
@@ -19,14 +19,23 @@ export function redactSecrets<T>(value: T, secrets: string[]): T {
     return redacted as T;
   }
 
-  if (Array.isArray(value)) {
-    return value.map((item) => redactSecrets(item, secrets)) as T;
-  }
-
   if (value !== null && typeof value === "object") {
+    if (!seen) seen = new WeakMap();
+    if (seen.has(value as object)) return seen.get(value as object) as T;
+
+    if (Array.isArray(value)) {
+      const result: unknown[] = [];
+      seen.set(value as object, result);
+      for (const item of value) {
+        result.push(redactSecrets(item, secrets, seen));
+      }
+      return result as T;
+    }
+
     const result: Record<string, unknown> = {};
+    seen.set(value as object, result);
     for (const [key, val] of Object.entries(value)) {
-      result[key] = redactSecrets(val, secrets);
+      result[key] = redactSecrets(val, secrets, seen);
     }
     return result as T;
   }


### PR DESCRIPTION
Use a WeakMap to track visited objects and map them to their redacted results. This prevents infinite recursion and ensures secrets are redacted even through circular reference paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core redaction recursion to track and reuse seen objects/arrays; low behavioral surface area but could subtly affect identity/structure of returned objects for complex inputs.
> 
> **Overview**
> Fixes `redactSecrets` to safely handle circular references by tracking visited objects/arrays in a `WeakMap` and reusing the already-redacted result to avoid infinite recursion.
> 
> Adds a regression test asserting circular structures are preserved (self-references point to the redacted clone) while still redacting secret strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5409afcdd41699e7790316be42998e62c9088be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->