### PR TITLE
add onError callback with secret redaction for external error reporting

### DIFF
--- a/packages/runtimeuse/package-lock.json
+++ b/packages/runtimeuse/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runtimeuse",
-  "version": "0.3.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runtimeuse",
-      "version": "0.3.0",
+      "version": "0.9.1",
       "license": "FSL",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.73",

--- a/packages/runtimeuse/src/error-utils.ts
+++ b/packages/runtimeuse/src/error-utils.ts
@@ -1,3 +1,5 @@
+import { redactSecrets } from "./utils.js";
+
 const MAX_DEPTH = 4;
 const MAX_ARRAY_ITEMS = 20;
 const MAX_OBJECT_KEYS = 20;
@@ -111,6 +113,29 @@ export function serializeErrorMetadata(error: unknown): Record<string, unknown> 
   }
 
   return { error_type: typeof error };
+}
+
+export function redactError(error: unknown, secrets: string[]): unknown {
+  if (secrets.length === 0) return error;
+
+  if (error instanceof Error) {
+    const redacted = new Error(redactSecrets(error.message, secrets));
+    redacted.name = error.name;
+    if (error.stack) {
+      redacted.stack = redactSecrets(error.stack, secrets);
+    }
+    if (error.cause !== undefined) {
+      redacted.cause = redactError(error.cause, secrets);
+    }
+    for (const [key, val] of Object.entries(error)) {
+      if (!["name", "message", "stack", "cause"].includes(key)) {
+        (redacted as unknown as Record<string, unknown>)[key] = redactSecrets(val, secrets);
+      }
+    }
+    return redacted;
+  }
+
+  return redactSecrets(error, secrets);
 }
 
 export function withErrorMetadata(

--- a/packages/runtimeuse/src/server.ts
+++ b/packages/runtimeuse/src/server.ts
@@ -3,6 +3,7 @@ import type { AgentHandler } from "./agent-handler.js";
 import { WebSocketSession, type SessionConfig } from "./session.js";
 import { UploadTracker } from "./upload-tracker.js";
 import { defaultLogger, type Logger } from "./logger.js";
+import { serializeErrorMetadata } from "./error-utils.js";
 
 export interface RuntimeUseServerConfig {
   handler: AgentHandler;
@@ -11,6 +12,7 @@ export interface RuntimeUseServerConfig {
   artifactWaitMs?: number;
   postInvocationDelayMs?: number;
   logger?: Logger;
+  onError?: (error: unknown, metadata: Record<string, unknown>) => void;
 }
 
 export class RuntimeUseServer {
@@ -37,10 +39,19 @@ export class RuntimeUseServer {
       artifactWaitMs: this.config.artifactWaitMs,
       postInvocationDelayMs: this.config.postInvocationDelayMs,
       logger: this.config.logger,
+      onError: this.config.onError,
     };
     const session = new WebSocketSession(ws, sessionConfig);
     session.run().catch((error) => {
       this.logger.error("Session error:", error);
+      try {
+        this.config.onError?.(error, {
+          ...serializeErrorMetadata(error),
+          phase: "session",
+        });
+      } catch {
+        // onError must not propagate
+      }
     });
   }
 

--- a/packages/runtimeuse/src/session.ts
+++ b/packages/runtimeuse/src/session.ts
@@ -4,7 +4,7 @@ import type { AgentHandler } from "./agent-handler.js";
 import { ArtifactManager } from "./artifact-manager.js";
 import type { UploadTracker } from "./upload-tracker.js";
 import type { InvocationMessage, CommandExecutionMessage, IncomingMessage, OutgoingMessage } from "./types.js";
-import { getErrorMessage, serializeErrorMetadata } from "./error-utils.js";
+import { getErrorMessage, serializeErrorMetadata, redactError } from "./error-utils.js";
 import { redactSecrets, sleep } from "./utils.js";
 import { createLogger, createRedactingLogger, defaultLogger, type Logger } from "./logger.js";
 import { InvocationRunner } from "./invocation-runner.js";
@@ -16,6 +16,7 @@ export interface SessionConfig {
   artifactWaitMs?: number;
   postInvocationDelayMs?: number;
   logger?: Logger;
+  onError?: (error: unknown, metadata: Record<string, unknown>) => void;
 }
 
 export class WebSocketSession {
@@ -42,6 +43,7 @@ export class WebSocketSession {
           await this.handleMessage(message, resolve);
         } catch (error) {
           this.logger.error("Error processing message:", error);
+          this.reportError(error, { phase: "message_parsing" });
           this.send({
             message_type: "error_message",
             error: getErrorMessage(error),
@@ -62,6 +64,7 @@ export class WebSocketSession {
 
       this.ws.on("error", (error) => {
         this.logger.error("WebSocket error:", error);
+        this.reportError(error, { phase: "websocket" });
       });
     });
   }
@@ -87,6 +90,7 @@ export class WebSocketSession {
           await this.artifactManager?.handleUploadResponse(message);
         } catch (error) {
           this.logger.error("Error uploading artifact:", error);
+          this.reportError(error, { phase: "artifact_upload" });
           this.send({
             message_type: "error_message",
             error: getErrorMessage(error),
@@ -158,6 +162,11 @@ export class WebSocketSession {
         return;
       }
       this.logger.error("Error in agent execution:", error);
+      this.reportError(error, {
+        phase: "agent_execution",
+        source_id: sourceId,
+        model: message.model,
+      });
       this.send({
         message_type: "error_message",
         error: getErrorMessage(error),
@@ -191,6 +200,10 @@ export class WebSocketSession {
         return;
       }
       this.logger.error("Error in command execution:", error);
+      this.reportError(error, {
+        phase: "command_execution",
+        source_id: sourceId,
+      });
       this.send({
         message_type: "error_message",
         error: getErrorMessage(error),
@@ -223,6 +236,20 @@ export class WebSocketSession {
     );
     this.logger.log("All artifacts uploaded.");
     this.ws.close();
+  }
+
+  private reportError(error: unknown, context: Record<string, unknown> = {}): void {
+    try {
+      this.config.onError?.(
+        redactError(error, this.secrets),
+        redactSecrets({
+          ...serializeErrorMetadata(error),
+          ...context,
+        }, this.secrets),
+      );
+    } catch {
+      // onError must not propagate — swallow to protect the caller's catch block
+    }
   }
 
   private send(data: OutgoingMessage): void {


### PR DESCRIPTION
Replace implicit error swallowing with an explicit onError hook that callers can wire to their own reporting (e.g. Sentry). Errors and metadata are redacted via redactError/redactSecrets before reaching the callback, and the callback is wrapped in try/catch so it can never break the session's own error handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `onError` callback into the WebSocket server/session error paths and changes how errors are propagated to external handlers; mistakes could leak sensitive data or alter observability behavior. Redaction and try/catch guards reduce blast radius but the hook runs in multiple failure scenarios.
> 
> **Overview**
> Adds an optional `onError(error, metadata)` hook to `RuntimeUseServer`/`WebSocketSession` so callers can report internal failures (e.g., parsing, websocket, artifact upload, agent/command execution, and top-level session errors).
> 
> Introduces `redactError` in `error-utils.ts` and uses it (plus `redactSecrets`) to ensure errors/stack traces and serialized metadata are secret-redacted before invoking `onError`, and wraps callback execution in `try/catch` so reporting cannot break session error handling.
> 
> Also bumps the `runtimeuse` package-lock version from `0.3.0` to `0.9.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f51c1c7cf231e54ff1a4f2ed79368fb8a796a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->