### PR TITLE
Fix delayed cancellation message

### DIFF
--- a/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
@@ -120,89 +120,90 @@ class RuntimeUseClient:
 
         wire_result: ResultMessageInterface | None = None
 
-        async with asyncio.timeout(options.timeout):
-            async for message in self._transport(send_queue=send_queue):
-                if self._abort_event.is_set():
-                    raise CancelledException("Query was cancelled")
+        try:
+            async with asyncio.timeout(options.timeout):
+                async for message in self._transport(send_queue=send_queue):
+                    if self._abort_event.is_set():
+                        raise CancelledException("Query was cancelled")
 
-                try:
-                    message_interface = AgentRuntimeMessageInterface.model_validate(
-                        message
-                    )
-                except pydantic.ValidationError:
-                    logger.error(
-                        f"Received unknown message type from agent runtime: {message}"
-                    )
-                    continue
-
-                if message_interface.message_type == "result_message":
-                    wire_result = ResultMessageInterface.model_validate(message)
-                    logger.info(
-                        f"Received result message from agent runtime: {message}"
-                    )
-                    continue
-
-                elif message_interface.message_type == "assistant_message":
-                    if options.on_assistant_message is not None:
-                        assistant_message_interface = (
-                            AssistantMessageInterface.model_validate(message)
-                        )
-                        await options.on_assistant_message(assistant_message_interface)
-                    continue
-
-                elif message_interface.message_type == "error_message":
                     try:
-                        error_message_interface = ErrorMessageInterface.model_validate(
+                        message_interface = AgentRuntimeMessageInterface.model_validate(
                             message
                         )
                     except pydantic.ValidationError:
                         logger.error(
-                            f"Received malformed error message from agent runtime: {message}",
+                            f"Received unknown message type from agent runtime: {message}"
                         )
-                        raise AgentRuntimeError(str(message))
-                    logger.error(
-                        f"Error from agent runtime: {error_message_interface}",
-                    )
-                    raise AgentRuntimeError(
-                        error_message_interface.error,
-                        metadata=error_message_interface.metadata,
-                    )
+                        continue
 
-                elif (
-                    message_interface.message_type == "artifact_upload_request_message"
-                ):
-                    logger.info(
-                        f"Received artifact upload request message from agent runtime: {message}"
-                    )
-                    if options.on_artifact_upload_request is not None:
-                        artifact_upload_request_message_interface = (
-                            ArtifactUploadRequestMessageInterface.model_validate(
+                    if message_interface.message_type == "result_message":
+                        wire_result = ResultMessageInterface.model_validate(message)
+                        logger.info(
+                            f"Received result message from agent runtime: {message}"
+                        )
+                        continue
+
+                    elif message_interface.message_type == "assistant_message":
+                        if options.on_assistant_message is not None:
+                            assistant_message_interface = (
+                                AssistantMessageInterface.model_validate(message)
+                            )
+                            await options.on_assistant_message(assistant_message_interface)
+                        continue
+
+                    elif message_interface.message_type == "error_message":
+                        try:
+                            error_message_interface = ErrorMessageInterface.model_validate(
                                 message
                             )
-                        )
-                        upload_result = await options.on_artifact_upload_request(
-                            artifact_upload_request_message_interface
-                        )
-                        artifact_upload_response_message_interface = ArtifactUploadResponseMessageInterface(
-                            message_type="artifact_upload_response_message",
-                            filename=artifact_upload_request_message_interface.filename,
-                            filepath=artifact_upload_request_message_interface.filepath,
-                            presigned_url=upload_result.presigned_url,
-                            content_type=upload_result.content_type,
-                        )
-                        await send_queue.put(
-                            artifact_upload_response_message_interface.model_dump(
-                                mode="json"
+                        except pydantic.ValidationError:
+                            logger.error(
+                                f"Received malformed error message from agent runtime: {message}",
                             )
+                            raise AgentRuntimeError(str(message))
+                        logger.error(
+                            f"Error from agent runtime: {error_message_interface}",
                         )
-                    continue
+                        raise AgentRuntimeError(
+                            error_message_interface.error,
+                            metadata=error_message_interface.metadata,
+                        )
 
-                else:
-                    logger.info(
-                        f"Received non-result message from agent runtime: {message}"
-                    )
+                    elif (
+                        message_interface.message_type == "artifact_upload_request_message"
+                    ):
+                        logger.info(
+                            f"Received artifact upload request message from agent runtime: {message}"
+                        )
+                        if options.on_artifact_upload_request is not None:
+                            artifact_upload_request_message_interface = (
+                                ArtifactUploadRequestMessageInterface.model_validate(
+                                    message
+                                )
+                            )
+                            upload_result = await options.on_artifact_upload_request(
+                                artifact_upload_request_message_interface
+                            )
+                            artifact_upload_response_message_interface = ArtifactUploadResponseMessageInterface(
+                                message_type="artifact_upload_response_message",
+                                filename=artifact_upload_request_message_interface.filename,
+                                filepath=artifact_upload_request_message_interface.filepath,
+                                presigned_url=upload_result.presigned_url,
+                                content_type=upload_result.content_type,
+                            )
+                            await send_queue.put(
+                                artifact_upload_response_message_interface.model_dump(
+                                    mode="json"
+                                )
+                            )
+                        continue
 
-        self._send_queue = None
+                    else:
+                        logger.info(
+                            f"Received non-result message from agent runtime: {message}"
+                        )
+        finally:
+            self._send_queue = None
 
         if self._abort_event.is_set():
             raise CancelledException("Query was cancelled")
@@ -252,87 +253,88 @@ class RuntimeUseClient:
 
         wire_result: CommandExecutionResultMessageInterface | None = None
 
-        async with asyncio.timeout(options.timeout):
-            async for msg in self._transport(send_queue=send_queue):
-                if self._abort_event.is_set():
-                    raise CancelledException("Command execution was cancelled")
+        try:
+            async with asyncio.timeout(options.timeout):
+                async for msg in self._transport(send_queue=send_queue):
+                    if self._abort_event.is_set():
+                        raise CancelledException("Command execution was cancelled")
 
-                try:
-                    message_interface = AgentRuntimeMessageInterface.model_validate(msg)
-                except pydantic.ValidationError:
-                    logger.error(
-                        f"Received unknown message type from agent runtime: {msg}"
-                    )
-                    continue
-
-                if message_interface.message_type == "command_execution_result_message":
-                    wire_result = CommandExecutionResultMessageInterface.model_validate(
-                        msg
-                    )
-                    logger.info(
-                        f"Received command execution result from agent runtime: {msg}"
-                    )
-                    continue
-
-                elif message_interface.message_type == "assistant_message":
-                    if options.on_assistant_message is not None:
-                        assistant_message_interface = (
-                            AssistantMessageInterface.model_validate(msg)
-                        )
-                        await options.on_assistant_message(assistant_message_interface)
-                    continue
-
-                elif message_interface.message_type == "error_message":
                     try:
-                        error_message_interface = ErrorMessageInterface.model_validate(
-                            msg
-                        )
+                        message_interface = AgentRuntimeMessageInterface.model_validate(msg)
                     except pydantic.ValidationError:
                         logger.error(
-                            f"Received malformed error message from agent runtime: {msg}",
+                            f"Received unknown message type from agent runtime: {msg}"
                         )
-                        raise AgentRuntimeError(str(msg))
-                    logger.error(
-                        f"Error from agent runtime: {error_message_interface}",
-                    )
-                    raise AgentRuntimeError(
-                        error_message_interface.error,
-                        metadata=error_message_interface.metadata,
-                    )
+                        continue
 
-                elif (
-                    message_interface.message_type == "artifact_upload_request_message"
-                ):
-                    logger.info(
-                        f"Received artifact upload request message from agent runtime: {msg}"
-                    )
-                    if options.on_artifact_upload_request is not None:
-                        artifact_upload_request_message_interface = (
-                            ArtifactUploadRequestMessageInterface.model_validate(msg)
+                    if message_interface.message_type == "command_execution_result_message":
+                        wire_result = CommandExecutionResultMessageInterface.model_validate(
+                            msg
                         )
-                        upload_result = await options.on_artifact_upload_request(
-                            artifact_upload_request_message_interface
+                        logger.info(
+                            f"Received command execution result from agent runtime: {msg}"
                         )
-                        artifact_upload_response_message_interface = ArtifactUploadResponseMessageInterface(
-                            message_type="artifact_upload_response_message",
-                            filename=artifact_upload_request_message_interface.filename,
-                            filepath=artifact_upload_request_message_interface.filepath,
-                            presigned_url=upload_result.presigned_url,
-                            content_type=upload_result.content_type,
-                        )
-                        await send_queue.put(
-                            artifact_upload_response_message_interface.model_dump(
-                                mode="json"
+                        continue
+
+                    elif message_interface.message_type == "assistant_message":
+                        if options.on_assistant_message is not None:
+                            assistant_message_interface = (
+                                AssistantMessageInterface.model_validate(msg)
                             )
+                            await options.on_assistant_message(assistant_message_interface)
+                        continue
+
+                    elif message_interface.message_type == "error_message":
+                        try:
+                            error_message_interface = ErrorMessageInterface.model_validate(
+                                msg
+                            )
+                        except pydantic.ValidationError:
+                            logger.error(
+                                f"Received malformed error message from agent runtime: {msg}",
+                            )
+                            raise AgentRuntimeError(str(msg))
+                        logger.error(
+                            f"Error from agent runtime: {error_message_interface}",
                         )
-                    continue
+                        raise AgentRuntimeError(
+                            error_message_interface.error,
+                            metadata=error_message_interface.metadata,
+                        )
 
-                else:
-                    logger.info(
-                        f"Received non-result message from agent runtime: {msg}"
-                    )
+                    elif (
+                        message_interface.message_type == "artifact_upload_request_message"
+                    ):
+                        logger.info(
+                            f"Received artifact upload request message from agent runtime: {msg}"
+                        )
+                        if options.on_artifact_upload_request is not None:
+                            artifact_upload_request_message_interface = (
+                                ArtifactUploadRequestMessageInterface.model_validate(msg)
+                            )
+                            upload_result = await options.on_artifact_upload_request(
+                                artifact_upload_request_message_interface
+                            )
+                            artifact_upload_response_message_interface = ArtifactUploadResponseMessageInterface(
+                                message_type="artifact_upload_response_message",
+                                filename=artifact_upload_request_message_interface.filename,
+                                filepath=artifact_upload_request_message_interface.filepath,
+                                presigned_url=upload_result.presigned_url,
+                                content_type=upload_result.content_type,
+                            )
+                            await send_queue.put(
+                                artifact_upload_response_message_interface.model_dump(
+                                    mode="json"
+                                )
+                            )
+                        continue
 
-        self._send_queue = None
+                    else:
+                        logger.info(
+                            f"Received non-result message from agent runtime: {msg}"
+                        )
+        finally:
+            self._send_queue = None
 
         if self._abort_event.is_set():
             raise CancelledException("Command execution was cancelled")

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
@@ -52,6 +52,7 @@ class RuntimeUseClient:
             raise ValueError("Either ws_url or transport must be provided")
 
         self._abort_event = asyncio.Event()
+        self._send_queue: asyncio.Queue[dict] | None = None
 
     def abort(self) -> None:
         """Signal the current query to cancel.
@@ -61,6 +62,13 @@ class RuntimeUseClient:
         coroutine on the same event loop.
         """
         self._abort_event.set()
+        send_queue = self._send_queue
+        if send_queue is not None:
+            send_queue.put_nowait(
+                CancelMessage(message_type="cancel_message").model_dump(
+                    mode="json"
+                )
+            )
 
     async def query(
         self,
@@ -107,6 +115,7 @@ class RuntimeUseClient:
         )
 
         send_queue: asyncio.Queue[dict] = asyncio.Queue()
+        self._send_queue = send_queue
         await send_queue.put(invocation.model_dump(mode="json"))
 
         wire_result: ResultMessageInterface | None = None
@@ -114,13 +123,6 @@ class RuntimeUseClient:
         async with asyncio.timeout(options.timeout):
             async for message in self._transport(send_queue=send_queue):
                 if self._abort_event.is_set():
-                    logger.info("Query cancelled by caller")
-                    await send_queue.put(
-                        CancelMessage(message_type="cancel_message").model_dump(
-                            mode="json"
-                        )
-                    )
-                    await send_queue.join()
                     raise CancelledException("Query was cancelled")
 
                 try:
@@ -200,6 +202,11 @@ class RuntimeUseClient:
                         f"Received non-result message from agent runtime: {message}"
                     )
 
+        self._send_queue = None
+
+        if self._abort_event.is_set():
+            raise CancelledException("Query was cancelled")
+
         if wire_result is None:
             raise AgentRuntimeError("No result message received")
 
@@ -240,6 +247,7 @@ class RuntimeUseClient:
         )
 
         send_queue: asyncio.Queue[dict] = asyncio.Queue()
+        self._send_queue = send_queue
         await send_queue.put(message.model_dump(mode="json"))
 
         wire_result: CommandExecutionResultMessageInterface | None = None
@@ -247,13 +255,6 @@ class RuntimeUseClient:
         async with asyncio.timeout(options.timeout):
             async for msg in self._transport(send_queue=send_queue):
                 if self._abort_event.is_set():
-                    logger.info("Command execution cancelled by caller")
-                    await send_queue.put(
-                        CancelMessage(message_type="cancel_message").model_dump(
-                            mode="json"
-                        )
-                    )
-                    await send_queue.join()
                     raise CancelledException("Command execution was cancelled")
 
                 try:
@@ -330,6 +331,11 @@ class RuntimeUseClient:
                     logger.info(
                         f"Received non-result message from agent runtime: {msg}"
                     )
+
+        self._send_queue = None
+
+        if self._abort_event.is_set():
+            raise CancelledException("Command execution was cancelled")
 
         if wire_result is None:
             raise AgentRuntimeError("No result message received")


### PR DESCRIPTION
Send cancel message immediately on abort instead of deferring to next received message

Previously, the cancel message was only sent to the server when the next incoming message arrived in the async for loop. If the agent was busy and not sending messages, the cancel sat unsent indefinitely. Now abort() puts the cancel message directly on the send queue so the transport sends it over WebSocket right away.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async control flow and shared state (`self._send_queue`) in the request/response loop; could introduce edge cases if `abort()` is called outside an active request or concurrently.
> 
> **Overview**
> Fixes client-side cancellation so `abort()` immediately enqueues a `cancel_message` to the active transport send queue instead of waiting for the next inbound message.
> 
> Refactors `query()` and `execute_commands()` to track the current `send_queue` on the client (`self._send_queue`) with `try/finally` cleanup, and shifts cancellation handling to raise `CancelledException` promptly when the abort event is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93107d4058707adad7445c1fd5e554f6f68d77d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->