### PR TITLE
Drain artifact watcher before closing WS on end_session_message

### DIFF
--- a/packages/runtimeuse/package-lock.json
+++ b/packages/runtimeuse/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runtimeuse",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runtimeuse",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "FSL",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.73",

--- a/packages/runtimeuse/package.json
+++ b/packages/runtimeuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimeuse",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AI agent runtime with WebSocket protocol, artifact handling, and secret management",
   "license": "FSL",
   "type": "module",

--- a/packages/runtimeuse/src/session.ts
+++ b/packages/runtimeuse/src/session.ts
@@ -36,6 +36,7 @@ export class WebSocketSession {
   private requestInFlight = false;
   private secrets: string[] = [];
   private logger: Logger;
+  private drainPromise: Promise<void> | null = null;
 
   constructor(ws: WebSocket, config: SessionConfig) {
     this.ws = ws;
@@ -68,22 +69,7 @@ export class WebSocketSession {
         }
         this.logger.log("WebSocket connection closed");
         this.currentAbortController?.abort();
-
-        // Give chokidar time to observe files the agent wrote right before
-        // the session ended. Without this, late `add` events would not fire
-        // before we stop the watcher, and those artifacts would be lost.
-        const delayMs = this.config.postInvocationDelayMs ?? 3_000;
-        if (this.artifactManager && delayMs > 0) {
-          this.logger.log(`Waiting ${delayMs}ms for artifact watcher to drain...`);
-          await sleep(delayMs);
-        }
-        await this.artifactManager?.stopWatching();
-        await this.artifactManager?.waitForPendingRequests(
-          this.config.artifactWaitMs ?? 60_000,
-        );
-        await this.config.uploadTracker.waitForAll(
-          this.config.uploadTimeoutMs ?? 30_000,
-        );
+        await this.drain();
         resolve();
       });
 
@@ -97,6 +83,9 @@ export class WebSocketSession {
     switch (message.message_type) {
       case "end_session_message":
         this.logger.log("Received end_session_message. Closing session.");
+        // Drain the artifact watcher *before* closing so any late chokidar
+        // events still have an open socket to send upload requests through.
+        await this.drain();
         this.ws.close();
         return;
 
@@ -209,6 +198,26 @@ export class WebSocketSession {
       this.currentAbortController = null;
       this.requestInFlight = false;
     }
+  }
+
+  private drain(): Promise<void> {
+    if (!this.drainPromise) {
+      this.drainPromise = (async () => {
+        const delayMs = this.config.postInvocationDelayMs ?? 3_000;
+        if (this.artifactManager && delayMs > 0) {
+          this.logger.log(`Waiting ${delayMs}ms for artifact watcher to drain...`);
+          await sleep(delayMs);
+        }
+        await this.artifactManager?.stopWatching();
+        await this.artifactManager?.waitForPendingRequests(
+          this.config.artifactWaitMs ?? 60_000,
+        );
+        await this.config.uploadTracker.waitForAll(
+          this.config.uploadTimeoutMs ?? 30_000,
+        );
+      })();
+    }
+    return this.drainPromise;
   }
 
   private ensureArtifactManager(): void {


### PR DESCRIPTION
## Summary
- On `end_session_message`, `ws.close()` was called immediately and the 3s chokidar drain + pending-request wait ran in the close handler. Any `artifact_upload_request_message` produced by a late chokidar event during the drain was silently dropped because `send()` is gated on `readyState === OPEN`.
- Moved the drain into a memoized `drain()` helper invoked *before* `ws.close()` on the orderly path. The `close` handler still calls `drain()` for unexpected disconnects; memoization prevents double-draining.

## Test plan
- [x] `npx vitest run src/session.test.ts` — all 29 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session shutdown ordering and introduces memoized draining, which can affect artifact upload completeness and session close timing if edge cases exist (e.g., multiple close paths or long-running uploads). Scope is contained to `WebSocketSession` teardown logic plus a patch version bump.
> 
> **Overview**
> Ensures `end_session_message` drains the artifact watcher and waits for pending artifact uploads *before* calling `ws.close()`, so late chokidar events can still enqueue `artifact_upload_request_message` while the socket is open.
> 
> Refactors the shutdown sequence into a memoized `drain()` helper that is invoked from both the orderly end-session path and the WS `close` handler (for unexpected disconnects), preventing duplicate drain work.
> 
> Bumps `runtimeuse` version from `0.11.0` to `0.11.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79977a77703478b5f1aaadc3f9c0a01ca81b7b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->