### PR TITLE
Settle artifacts before sending terminal

### DIFF
--- a/packages/runtimeuse/package-lock.json
+++ b/packages/runtimeuse/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runtimeuse",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runtimeuse",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "FSL",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.73",

--- a/packages/runtimeuse/package.json
+++ b/packages/runtimeuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimeuse",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "AI agent runtime with WebSocket protocol, artifact handling, and secret management",
   "license": "FSL",
   "type": "module",

--- a/packages/runtimeuse/src/session.ts
+++ b/packages/runtimeuse/src/session.ts
@@ -188,11 +188,22 @@ export class WebSocketSession {
         }
       }
 
-      // The artifact watcher stays alive for the whole session, so we no
-      // longer block each request on a 3s drain. Artifacts that finish
-      // writing after the terminal will still fire chokidar events and be
-      // uploaded; on session close we do a single drain for any that were
-      // written right before the ws closed.
+      // Settle any artifacts written by this request before sending the
+      // terminal. Chokidar's awaitWriteFinish delays `add` events by ~2s,
+      // and the server typically closes the socket immediately after we
+      // respond — so artifacts requested *after* the terminal would never
+      // get their upload response back. Wait for chokidar to catch up, then
+      // wait for the upload round-trips we've queued.
+      if (this.artifactManager) {
+        const delayMs = this.config.postInvocationDelayMs ?? 3_000;
+        if (delayMs > 0) {
+          this.logger.log(`Waiting ${delayMs}ms for artifacts to settle...`);
+          await sleep(delayMs);
+        }
+        await this.artifactManager.waitForPendingRequests(
+          this.config.artifactWaitMs ?? 60_000,
+        );
+      }
       this.send(terminal);
     } finally {
       this.currentAbortController = null;


### PR DESCRIPTION
## Summary
PR #29 moved the drain to run before `ws.close()` on orderly session end. But the log below shows the drain still happens after the WS is closed:

```
Waiting 3000ms for artifact watcher to drain...
WebSocket connection closed
Requesting upload for artifact: deterministic-test.zip
Stopping artifact watcher
Waiting for 1 artifact round-trips...   ← hangs, upload response will never come
```

The server closes the WS immediately after sending `end_session_message`, so anything we try to send between the terminal and close (including late chokidar-triggered `artifact_upload_request_message`s) is silently dropped by `send()`'s `readyState === OPEN` guard.

Chokidar's `awaitWriteFinish` delays `add` events by ~2s, so artifacts written by post-agent commands are always discovered *after* the terminal has already been sent.

Fix: move the drain (sleep + `waitForPendingRequests`) to run **before** `send(terminal)`. Now artifacts get uploaded while the server is still waiting on our reply, instead of trying to send on an already-dead socket.

Bumps version to 0.11.2.

## Test plan
- [x] `npx vitest run src/session.test.ts` — all 29 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request completion timing and artifact upload ordering in the WebSocket session, which could impact latency and introduce new waiting/hanging behavior if artifact uploads don’t complete as expected.
> 
> **Overview**
> Ensures artifacts produced during an invocation are **settled and their queued upload round-trips complete before** `send(terminal)` in `WebSocketSession.handleRequest`, avoiding artifact upload requests/responses being lost when the server closes the socket immediately after the terminal.
> 
> Bumps `runtimeuse` version from `0.11.1` to `0.11.2` (including `package-lock.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ce6ecf70752a3c7aa886eb509ca5f5ffdbbff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->