### PR TITLE
Add stdout to command execution results

### DIFF
--- a/packages/runtimeuse-client-python/pyproject.toml
+++ b/packages/runtimeuse-client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "runtimeuse-client"
-version = "0.11.0"
+version = "0.12.0"
 description = "Client library for AI agent runtime communication over WebSocket"
 readme = "README.md"
 license = {"text" = "FSL"}

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/types.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/types.py
@@ -120,6 +120,7 @@ class CommandExecutionMessage(BaseModel):
 class CommandResultItem(BaseModel):
     command: str
     exit_code: int
+    stdout: str | None = None
 
 
 class CommandExecutionResult(BaseModel):

--- a/packages/runtimeuse-client-python/test/e2e/test_e2e.py
+++ b/packages/runtimeuse-client-python/test/e2e/test_e2e.py
@@ -616,6 +616,8 @@ class TestExecuteCommands:
         assert len(result.results) == 1
         assert result.results[0].command == "echo hello"
         assert result.results[0].exit_code == 0
+        assert result.results[0].stdout is not None
+        assert "hello" in result.results[0].stdout
 
     async def test_multiple_commands_success(
         self, client: RuntimeUseClient, make_execute_commands_options
@@ -631,8 +633,12 @@ class TestExecuteCommands:
         assert len(result.results) == 2
         assert result.results[0].command == "echo first"
         assert result.results[0].exit_code == 0
+        assert result.results[0].stdout is not None
+        assert "first" in result.results[0].stdout
         assert result.results[1].command == "echo second"
         assert result.results[1].exit_code == 0
+        assert result.results[1].stdout is not None
+        assert "second" in result.results[1].stdout
 
     async def test_command_output_streamed_via_callback(
         self, client: RuntimeUseClient, make_execute_commands_options
@@ -664,6 +670,7 @@ class TestExecuteCommands:
         assert len(result.results) == 1
         assert result.results[0].command == "exit 1"
         assert result.results[0].exit_code == 1
+        assert not result.results[0].stdout
 
     async def test_failed_command_skips_remaining(
         self, client: RuntimeUseClient, make_execute_commands_options
@@ -680,8 +687,11 @@ class TestExecuteCommands:
         assert len(result.results) == 2
         assert result.results[0].command == "echo first"
         assert result.results[0].exit_code == 0
+        assert result.results[0].stdout is not None
+        assert "first" in result.results[0].stdout
         assert result.results[1].command == "exit 2"
         assert result.results[1].exit_code == 2
+        assert not result.results[1].stdout
 
     async def test_agent_handler_not_invoked(
         self, client: RuntimeUseClient, make_execute_commands_options
@@ -702,7 +712,7 @@ class TestExecuteCommands:
         async def on_msg(msg: AssistantMessageInterface):
             received.append(msg)
 
-        await client.execute_commands(
+        result = await client.execute_commands(
             commands=[CommandInterface(command="pwd", cwd="/tmp")],
             options=make_execute_commands_options(
                 on_assistant_message=on_msg, timeout=10
@@ -711,6 +721,8 @@ class TestExecuteCommands:
 
         all_text = [block for msg in received for block in msg.text_blocks]
         assert any("/tmp" in t for t in all_text)
+        assert result.results[0].stdout is not None
+        assert "/tmp" in result.results[0].stdout
 
     async def test_secrets_redacted_from_output(
         self, client: RuntimeUseClient, make_execute_commands_options

--- a/packages/runtimeuse-client-python/test/sandbox/test_e2b.py
+++ b/packages/runtimeuse-client-python/test/sandbox/test_e2b.py
@@ -60,7 +60,10 @@ class TestE2BSandbox:
             assert isinstance(result, CommandExecutionResult)
             assert len(result.results) == 2
             assert result.results[0].exit_code == 0
+            assert result.results[0].stdout is not None
+            assert "hello-from-e2b" in result.results[0].stdout
             assert result.results[1].exit_code == 0
+            assert result.results[1].stdout is not None
 
             all_text = [block for msg in received for block in msg.text_blocks]
             assert any("hello-from-e2b" in t for t in all_text)
@@ -81,6 +84,7 @@ class TestE2BSandbox:
             assert isinstance(result, CommandExecutionResult)
             assert len(result.results) == 1
             assert result.results[0].exit_code == 1
+            assert not result.results[0].stdout
         finally:
             sandbox.kill()
 
@@ -100,6 +104,9 @@ class TestE2BSandbox:
             assert isinstance(result, CommandExecutionResult)
             assert len(result.results) == 2
             assert result.results[0].exit_code == 0
+            assert result.results[0].stdout is not None
+            assert "first" in result.results[0].stdout
             assert result.results[1].exit_code == 1
+            assert not result.results[1].stdout
         finally:
             sandbox.kill()

--- a/packages/runtimeuse-client-python/test/test_client.py
+++ b/packages/runtimeuse-client-python/test/test_client.py
@@ -515,7 +515,7 @@ class TestConstructor:
 
 COMMAND_RESULT_MSG = {
     "message_type": "command_execution_result_message",
-    "results": [{"command": "echo hello", "exit_code": 0}],
+    "results": [{"command": "echo hello", "exit_code": 0, "stdout": "hello\n"}],
 }
 
 
@@ -535,6 +535,7 @@ class TestExecuteCommands:
         assert len(result.results) == 1
         assert result.results[0].command == "echo hello"
         assert result.results[0].exit_code == 0
+        assert result.results[0].stdout == "hello\n"
 
     @pytest.mark.asyncio
     async def test_sends_command_execution_message(
@@ -614,6 +615,7 @@ class TestExecuteCommands:
         assert isinstance(result, CommandExecutionResult)
         assert len(result.results) == 1
         assert result.results[0].exit_code == 1
+        assert result.results[0].stdout is None
 
     @pytest.mark.asyncio
     async def test_failed_command_skips_remaining(
@@ -622,7 +624,7 @@ class TestExecuteCommands:
         result_msg = {
             "message_type": "command_execution_result_message",
             "results": [
-                {"command": "echo first", "exit_code": 0},
+                {"command": "echo first", "exit_code": 0, "stdout": "first\n"},
                 {"command": "exit 1", "exit_code": 1},
             ],
         }
@@ -639,7 +641,9 @@ class TestExecuteCommands:
 
         assert len(result.results) == 2
         assert result.results[0].exit_code == 0
+        assert result.results[0].stdout == "first\n"
         assert result.results[1].exit_code == 1
+        assert result.results[1].stdout is None
 
     @pytest.mark.asyncio
     async def test_no_result_raises(
@@ -730,7 +734,7 @@ class TestExecuteCommands:
     ):
         result_msg = {
             "message_type": "command_execution_result_message",
-            "results": [{"command": "echo hello", "exit_code": 0}],
+            "results": [{"command": "echo hello", "exit_code": 0, "stdout": "hello\n"}],
         }
         transport, client = fake_transport([result_msg])
 
@@ -843,7 +847,7 @@ class TestPersistentSession:
                 [
                     {
                         "message_type": "command_execution_result_message",
-                        "results": [{"command": "echo x", "exit_code": 0}],
+                        "results": [{"command": "echo x", "exit_code": 0, "stdout": "x\n"}],
                     }
                 ],
             ]
@@ -860,6 +864,7 @@ class TestPersistentSession:
 
         assert query_result.data.text == "persistent hello"
         assert cmd_result.results[0].command == "echo x"
+        assert cmd_result.results[0].stdout == "x\n"
 
     @pytest.mark.asyncio
     async def test_cancel_mid_session_then_another_call(

--- a/packages/runtimeuse/package.json
+++ b/packages/runtimeuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimeuse",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "AI agent runtime with WebSocket protocol, artifact handling, and secret management",
   "license": "FSL",
   "type": "module",

--- a/packages/runtimeuse/src/command-handler.test.ts
+++ b/packages/runtimeuse/src/command-handler.test.ts
@@ -207,7 +207,7 @@ describe("CommandHandler", () => {
       closeHandler(0);
 
       const result = await promise;
-      expect(result).toEqual({ exitCode: 0 });
+      expect(result).toEqual({ exitCode: 0, stdout: "output" });
     });
 
     it("resolves with exitCode 1 on close with code 1", async () => {
@@ -222,7 +222,7 @@ describe("CommandHandler", () => {
       closeHandler(1);
 
       const result = await promise;
-      expect(result).toEqual({ exitCode: 1 });
+      expect(result).toEqual({ exitCode: 1, stdout: undefined });
     });
 
     it("resolves with exitCode 1 and error when callback reports code 1", async () => {
@@ -250,7 +250,7 @@ describe("CommandHandler", () => {
       closeHandler(139);
 
       const result = await promise;
-      expect(result).toEqual({ exitCode: 139 });
+      expect(result).toEqual({ exitCode: 139, stdout: undefined });
     });
 
     it("resolves when callback reports a non-1 error code", async () => {
@@ -470,6 +470,60 @@ describe("CommandHandler", () => {
 
       await promise;
       expect(onStdout).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stdout capture", () => {
+    it("includes stdout in the result on success", async () => {
+      const handler = createHandler({ command: "echo hello" });
+
+      const promise = handler.execute();
+
+      execCallback(null, "hello\n", "");
+      const closeHandler = execChild.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "close",
+      )[1];
+      closeHandler(0);
+
+      const result = await promise;
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("hello\n");
+    });
+
+    it("returns undefined stdout when command produces no output", async () => {
+      const handler = createHandler({ command: "true" });
+
+      const promise = handler.execute();
+
+      execCallback(null, "", "");
+      const closeHandler = execChild.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "close",
+      )[1];
+      closeHandler(0);
+
+      const result = await promise;
+      expect(result.stdout).toBeUndefined();
+    });
+
+    it("redacts secrets from captured stdout", async () => {
+      const handler = createHandler(
+        { command: "echo" },
+        new AbortController(),
+        undefined,
+        undefined,
+        ["my-secret"],
+      );
+
+      const promise = handler.execute();
+
+      execCallback(null, "token=my-secret here", "");
+      const closeHandler = execChild.on.mock.calls.find(
+        (c: unknown[]) => c[0] === "close",
+      )[1];
+      closeHandler(0);
+
+      const result = await promise;
+      expect(result.stdout).toBe("token=[REDACTED] here");
     });
   });
 });

--- a/packages/runtimeuse/src/command-handler.ts
+++ b/packages/runtimeuse/src/command-handler.ts
@@ -7,6 +7,7 @@ import { redactSecrets } from "./utils.js";
 export interface CommandResult {
   exitCode: number;
   error?: ExecFileException;
+  stdout?: string;
 }
 
 export interface CommandHandlerOptions {
@@ -44,6 +45,7 @@ class CommandHandler {
       }
     }
     return new Promise((resolve, reject) => {
+      let capturedStdout = "";
       const result = exec(
         this.command.command,
         {
@@ -52,6 +54,7 @@ class CommandHandler {
           signal: this.abortController.signal,
         },
         (error, stdout, stderr) => {
+          capturedStdout = stdout;
           if (error) {
             const code =
               typeof error.code === "number" ? error.code : -1;
@@ -81,7 +84,10 @@ class CommandHandler {
 
       result.on("close", (code) => {
         this.logger.log("Command closed with code:", code);
-        return resolve({ exitCode: code ?? 0 });
+        const stdout = capturedStdout
+          ? this.redactSecrets(capturedStdout)
+          : undefined;
+        return resolve({ exitCode: code ?? 0, stdout });
       });
     });
   }

--- a/packages/runtimeuse/src/invocation-runner.test.ts
+++ b/packages/runtimeuse/src/invocation-runner.test.ts
@@ -18,7 +18,7 @@ const mockExecute =
       command: { command: string; cwd?: string };
       onStdout?: (stdout: string) => void;
       onStderr?: (stderr: string) => void;
-    }) => Promise<{ exitCode: number }>
+    }) => Promise<{ exitCode: number; stdout?: string }>
   >();
 
 vi.mock("./download-handler.js", () => ({
@@ -423,18 +423,22 @@ describe("InvocationRunner.runCommandsOnly", () => {
   });
 
   it("returns command_execution_result_message on success", async () => {
+    mockExecute.mockResolvedValue({ exitCode: 0, stdout: "hello\n" });
     const { runner, message } = createCommandRunner();
 
     const result = await runner.runCommandsOnly(message);
 
     expect(result).toEqual({
       message_type: "command_execution_result_message",
-      results: [{ command: "echo hello", exit_code: 0 }],
+      results: [{ command: "echo hello", exit_code: 0, stdout: "hello\n" }],
     });
     expect(mockHandlerRun).not.toHaveBeenCalled();
   });
 
   it("collects results for multiple commands", async () => {
+    mockExecute
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "1\n" })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "2\n" });
     const { runner, message } = createCommandRunner({
       commands: [
         { command: "echo 1", cwd: "/app" },
@@ -447,8 +451,8 @@ describe("InvocationRunner.runCommandsOnly", () => {
     expect(result).toEqual({
       message_type: "command_execution_result_message",
       results: [
-        { command: "echo 1", exit_code: 0 },
-        { command: "echo 2", exit_code: 0 },
+        { command: "echo 1", exit_code: 0, stdout: "1\n" },
+        { command: "echo 2", exit_code: 0, stdout: "2\n" },
       ],
     });
   });
@@ -482,7 +486,7 @@ describe("InvocationRunner.runCommandsOnly", () => {
 
     expect(result).toEqual({
       message_type: "command_execution_result_message",
-      results: [{ command: "echo hello", exit_code: 2 }],
+      results: [{ command: "echo hello", exit_code: 2, stdout: undefined }],
     });
     expect(send).not.toHaveBeenCalledWith(
       expect.objectContaining({ message_type: "error_message" }),
@@ -504,7 +508,7 @@ describe("InvocationRunner.runCommandsOnly", () => {
 
     expect(result).toEqual({
       message_type: "command_execution_result_message",
-      results: [{ command: "failing", exit_code: 1 }],
+      results: [{ command: "failing", exit_code: 1, stdout: undefined }],
     });
   });
 

--- a/packages/runtimeuse/src/invocation-runner.ts
+++ b/packages/runtimeuse/src/invocation-runner.ts
@@ -128,7 +128,11 @@ export class InvocationRunner {
     });
 
     const result = await handler.execute();
-    results.push({ command: command.command, exit_code: result.exitCode });
+    results.push({
+      command: command.command,
+      exit_code: result.exitCode,
+      stdout: result.stdout,
+    });
     return result.exitCode;
   }
 

--- a/packages/runtimeuse/src/session.test.ts
+++ b/packages/runtimeuse/src/session.test.ts
@@ -540,7 +540,7 @@ describe("WebSocketSession", () => {
     };
 
     it("sends command_execution_result_message on success", async () => {
-      mockCommandExecute.mockResolvedValueOnce({ exitCode: 0 });
+      mockCommandExecute.mockResolvedValueOnce({ exitCode: 0, stdout: "hello\n" });
       const { session, ws } = createSession();
       const done = session.run();
       sendMessage(ws, COMMAND_EXEC_MSG);
@@ -553,7 +553,7 @@ describe("WebSocketSession", () => {
       );
       expect(result).toBeDefined();
       expect(result!.results).toEqual([
-        { command: "echo hello", exit_code: 0 },
+        { command: "echo hello", exit_code: 0, stdout: "hello\n" },
       ]);
     });
 
@@ -581,9 +581,8 @@ describe("WebSocketSession", () => {
         (m) => m.message_type === "command_execution_result_message",
       );
       expect(result).toBeDefined();
-      expect(result!.results).toEqual([
-        { command: "echo hello", exit_code: 1 },
-      ]);
+      expect(result!.results[0].command).toBe("echo hello");
+      expect(result!.results[0].exit_code).toBe(1);
       const errors = sent.filter((m) => m.message_type === "error_message");
       expect(errors).toHaveLength(0);
     });
@@ -606,8 +605,8 @@ describe("WebSocketSession", () => {
 
     it("handles two sequential command_execution_messages on one socket", async () => {
       mockCommandExecute
-        .mockResolvedValueOnce({ exitCode: 0 })
-        .mockResolvedValueOnce({ exitCode: 0 });
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "first\n" })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "second\n" });
 
       const { session, ws } = createSession();
       const done = session.run();
@@ -630,7 +629,9 @@ describe("WebSocketSession", () => {
       );
       expect(results).toHaveLength(2);
       expect(results[0].results[0].command).toBe("echo first");
+      expect(results[0].results[0].stdout).toBe("first\n");
       expect(results[1].results[0].command).toBe("echo second");
+      expect(results[1].results[0].stdout).toBe("second\n");
 
       await endSession(ws, done);
     });

--- a/packages/runtimeuse/src/types.ts
+++ b/packages/runtimeuse/src/types.ts
@@ -36,6 +36,7 @@ interface CommandExecutionMessage {
 interface CommandExecutionResultItem {
   command: string;
   exit_code: number;
+  stdout?: string;
 }
 
 interface CommandExecutionResultMessage {


### PR DESCRIPTION
## Summary

- Capture buffered stdout from `CommandHandler.execute()` and include it in `CommandResult` so the full command output is available in the final result, not just via the real-time streaming callbacks.
- Thread the new `stdout` field through the wire protocol (`CommandExecutionResultItem`) and the Python client (`CommandResultItem`).
- Bump both `runtimeuse` and `runtimeuse-client` to 0.12.0.

## Test plan

- [x] TypeScript unit tests pass (`npm test` — 143 tests)
- [x] Python unit tests pass (`pytest test/test_client.py` — 44 tests)
- [x] E2E tests pass (`pytest test -m e2e` — 36 tests)
- [x] E2B sandbox tests (require `E2B_API_KEY`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the command execution wire protocol and result types to include buffered `stdout`, which may affect clients expecting the old schema and increases returned payload size. Logic is straightforward but touches runtime execution and cross-language compatibility (TS server + Python client).
> 
> **Overview**
> **Command-only execution results now include buffered stdout.** `CommandHandler.execute()` captures the final `stdout` (with secret redaction) and returns it alongside `exitCode`, and `InvocationRunner.runCommandsOnly` threads this through the `command_execution_result_message` payload.
> 
> The wire type `CommandExecutionResultItem` and the Python client model `CommandResultItem` add an optional `stdout` field, with tests updated/added to assert `stdout` presence on success and absence on failures. Package versions are bumped to `0.12.0` in both `runtimeuse` and `runtimeuse-client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccdcc96503a058db9996e346c2a92c4c62a628af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->