### PR TITLE
Document persistent sessions and command stdout

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -30,5 +30,6 @@ description: Run AI agents (Claude Code, OpenAI Agents, and more) in any sandbox
 - **Artifact uploads**: move generated files out of the sandbox with a presigned URL handshake.
 - **Streaming and cancellation**: receive progress updates and stop runs cleanly.
 - **Secret-aware execution**: redact sensitive values before they leave the sandbox.
+- **Persistent sessions**: run many sequential invocations and commands over a single WebSocket connection.
 
 

--- a/docs/content/docs/python-client.mdx
+++ b/docs/content/docs/python-client.mdx
@@ -41,6 +41,34 @@ asyncio.run(main())
 - `data`: either `TextResult` (`.text`) or `StructuredOutputResult` (`.structured_output`)
 - `metadata`: execution metadata returned by the runtime (includes token usage when available)
 
+## Persistent Sessions
+
+Use `client.session()` when you want to run several sequential `query()` or `execute_commands()` calls against the same sandbox without paying the connection cost each time. The session keeps a single WebSocket open until the context exits.
+
+```python
+async with client.session() as session:
+    summary = await session.query(
+        prompt="Summarize the repository.",
+        options=QueryOptions(
+            system_prompt="You are a helpful assistant.",
+            model="gpt-4.1",
+        ),
+    )
+
+    commands = await session.execute_commands(
+        commands=[CommandInterface(command="ls /runtimeuse")],
+        options=ExecuteCommandsOptions(),
+    )
+```
+
+Calls inside a session are serialized: each one runs to completion (or cancellation) before the next is sent.
+
+`session.abort()` cancels only the in-flight request and leaves the session open for the next call. One-shot `client.abort()` is the equivalent for the convenience wrappers below.
+
+When the context exits, the client sends `end_session_message` and waits for the runtime to drain any artifact uploads triggered by post-agent commands before closing the socket — files written after the last call still make it out.
+
+The default `WebSocketTransport` supports persistent sessions. A custom transport must implement `PersistentTransport` for `client.session()` to work.
+
 ## Return Structured JSON
 
 Pass `output_format_json_schema_str` when your application needs machine-readable output instead of free-form text. The result will be a `StructuredOutputResult`.
@@ -194,7 +222,10 @@ result = await client.execute_commands(
 
 for item in result.results:
     print(f"{item.command} -> exit {item.exit_code}")
+    print(item.stdout)
 ```
+
+Each item in `result.results` carries `exit_code` and the buffered `stdout` from that command, alongside the real-time output delivered via `on_assistant_message`.
 
 `execute_commands()` supports the same callbacks and options as `query()`: streaming via `on_assistant_message`, artifact uploads, cancellation, timeout, and `secrets_to_redact`. Use `pre_execution_downloadables` to fetch files into the sandbox before the commands run.
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -202,22 +202,23 @@ from runtimeuse_client import (
 async def main(ws_url: str) -> None:
     client = RuntimeUseClient(ws_url=ws_url)
 
-    result = await client.query(
-        prompt="Summarize the contents of this repository and list your favorite file.",
-        options=QueryOptions(
-            system_prompt="You are a helpful assistant.",
-            model="claude-sonnet-4-20250514", # gpt-5.4 for openai
-            pre_agent_downloadables=[
-                RuntimeEnvironmentDownloadableInterface(
-                    download_url="https://github.com/openai/codex/archive/refs/heads/main.zip",
-                    working_dir="/runtimeuse",
-                )
-            ],
-        ),
-    )
+    async with client.session() as session:
+        result = await session.query(
+            prompt="Summarize the contents of this repository and list your favorite file.",
+            options=QueryOptions(
+                system_prompt="You are a helpful assistant.",
+                model="claude-sonnet-4-20250514", # gpt-5.4 for openai
+                pre_agent_downloadables=[
+                    RuntimeEnvironmentDownloadableInterface(
+                        download_url="https://github.com/openai/codex/archive/refs/heads/main.zip",
+                        working_dir="/runtimeuse",
+                    )
+                ],
+            ),
+        )
 
-    assert isinstance(result.data, TextResult)
-    print(result.data.text)
+        assert isinstance(result.data, TextResult)
+        print(result.data.text)
 
 
 asyncio.run(main(ws_url))


### PR DESCRIPTION
## Summary
- Add `## Persistent Sessions` section to `python-client.mdx` covering `client.session()`, `session.abort()` vs `client.abort()`, the end-of-session artifact drain, and the `PersistentTransport` requirement.
- Update the `execute_commands` example and prose to show the new `item.stdout` field on `CommandResultItem`.
- Switch the quickstart example to `async with client.session() as session:` so new users land on the recommended flow.
- Add a "persistent sessions" bullet to the landing page's "What it handles".

## Test plan
- [ ] Build the docs site locally and visually check the three updated pages render correctly.
- [ ] Confirm the quickstart code snippet compiles against runtimeuse-client 0.13.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only and do not affect runtime behavior. Main risk is minor: examples could drift from the actual client API/versioning.
> 
> **Overview**
> Documents **persistent sessions** for the Python client, adding guidance and an example for `client.session()` (including serialization behavior, `session.abort()` vs `client.abort()`, end-of-session artifact draining, and the `PersistentTransport` requirement).
> 
> Updates the `execute_commands()` docs to show and explain the per-command buffered `item.stdout`, and revises the Quickstart snippet to use `async with client.session() as session:` as the recommended flow. The landing page now lists *Persistent sessions* among supported capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cfecd9bfc2f74399356657a719e1e3ccbca608f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->