### PR TITLE
Tag command stdout/stderr as command_output_message

### DIFF
--- a/docs/content/docs/python-client.mdx
+++ b/docs/content/docs/python-client.mdx
@@ -175,12 +175,16 @@ result = await client.query(
 
 ## Stream Assistant Messages
 
-Use `on_assistant_message` when you want intermediate progress while the run is still happening.
+Use `on_assistant_message` to receive the agent's intermediate text output while the run is still happening, and `on_command_output` for stdout/stderr from any commands the runtime executes.
 
 ```python
 async def on_assistant_message(msg) -> None:
     for block in msg.text_blocks:
         print(f"[assistant] {block}")
+
+
+async def on_command_output(msg) -> None:
+    print(f"[{msg.stream}] {msg.command}: {msg.text}", end="")
 
 
 result = await client.query(
@@ -189,9 +193,12 @@ result = await client.query(
         system_prompt="You are a helpful assistant.",
         model="gpt-4.1",
         on_assistant_message=on_assistant_message,
+        on_command_output=on_command_output,
     ),
 )
 ```
+
+Each `command_output_message` carries the `stream` (`"stdout"` or `"stderr"`), the chunk of `text`, and the original `command` string.
 
 ## Run Commands Without the Agent
 
@@ -216,7 +223,7 @@ result = await client.execute_commands(
         CommandInterface(command="cat /app/output/status.txt"),
     ],
     options=ExecuteCommandsOptions(
-        on_assistant_message=on_assistant_message,  # streams stdout/stderr
+        on_command_output=on_command_output,  # streams stdout/stderr
     ),
 )
 
@@ -227,7 +234,7 @@ for item in result.results:
 
 Each item in `result.results` carries `exit_code` and the buffered `stdout` from that command, alongside the real-time output delivered via `on_assistant_message`.
 
-`execute_commands()` supports the same callbacks and options as `query()`: streaming via `on_assistant_message`, artifact uploads, cancellation, timeout, and `secrets_to_redact`. Use `pre_execution_downloadables` to fetch files into the sandbox before the commands run.
+`execute_commands()` supports the same callbacks and options as `query()`: streaming via `on_command_output`, artifact uploads, cancellation, timeout, and `secrets_to_redact`. Use `pre_execution_downloadables` to fetch files into the sandbox before the commands run.
 
 Each `CommandInterface` accepts an optional `env` dict that is merged on top of the sandbox's `process.env` for that command.
 

--- a/packages/runtimeuse-client-python/README.md
+++ b/packages/runtimeuse-client-python/README.md
@@ -117,7 +117,8 @@ result = await client.query(
         agent_env={"MY_VAR": "value"},               # optional -- env vars for the agent
         pre_agent_downloadables=[downloadable],          # optional
         output_format_json_schema_str='...',         # optional -- omit for text response
-        on_assistant_message=on_assistant,            # optional
+        on_assistant_message=on_assistant,            # optional -- agent text blocks
+        on_command_output=on_command_output,          # optional -- pre/post command stdout/stderr
         on_artifact_upload_request=on_artifact,       # optional -- return ArtifactUploadResult
         timeout=300,                                  # optional -- seconds
     ),
@@ -151,7 +152,7 @@ result = await client.execute_commands(
         CommandInterface(command="cat /app/output/status.txt", env={"MY_VAR": "value"}),
     ],
     options=ExecuteCommandsOptions(
-        on_assistant_message=on_assistant,  # optional -- streams stdout/stderr
+        on_command_output=on_command_output,  # optional -- streams stdout/stderr
     ),
 )
 

--- a/packages/runtimeuse-client-python/examples/runtime-client-example.py
+++ b/packages/runtimeuse-client-python/examples/runtime-client-example.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from src.runtimeuse_client import (
     AssistantMessageInterface,
+    CommandOutputMessageInterface,
     AgentRuntimeError,
     RuntimeUseClient,
     QueryOptions,
@@ -22,6 +23,9 @@ async def main():
 
     async def on_assistant_message(message: AssistantMessageInterface):
         print(f"Assistant message: {message.text_blocks}")
+
+    async def on_command_output(message: CommandOutputMessageInterface):
+        print(f"[{message.stream}] {message.command}: {message.text}", end="")
 
     try:
         result = await client.query(
@@ -41,6 +45,7 @@ async def main():
                     )
                 ],
                 on_assistant_message=on_assistant_message,
+                on_command_output=on_command_output,
             ),
         )
         assert isinstance(result.data, StructuredOutputResult)

--- a/packages/runtimeuse-client-python/examples/runtime-client-persistent-session-example.py
+++ b/packages/runtimeuse-client-python/examples/runtime-client-persistent-session-example.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from src.runtimeuse_client import (
     AssistantMessageInterface,
+    CommandOutputMessageInterface,
     AgentRuntimeError,
     ExecuteCommandsOptions,
     RuntimeUseClient,
@@ -27,6 +28,9 @@ async def main():
 
     async def on_assistant_message(message: AssistantMessageInterface):
         print(f"Assistant message: {message.text_blocks}")
+
+    async def on_command_output(message: CommandOutputMessageInterface):
+        print(f"[{message.stream}] {message.command}: {message.text}", end="")
 
     try:
         async with client.session() as session:
@@ -57,6 +61,7 @@ async def main():
                     ),
                     source_id="my-source",
                     on_assistant_message=on_assistant_message,
+                    on_command_output=on_command_output,
                 ),
             )
             assert isinstance(result.data, StructuredOutputResult)
@@ -78,7 +83,9 @@ async def main():
                             env={},
                         ),
                     ],
-                    options=ExecuteCommandsOptions(),
+                    options=ExecuteCommandsOptions(
+                        on_command_output=on_command_output,
+                    ),
                 )
                 print(f"Command result: {result}")
                 result = await session.query(

--- a/packages/runtimeuse-client-python/pyproject.toml
+++ b/packages/runtimeuse-client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "runtimeuse-client"
-version = "0.13.0"
+version = "0.14.0"
 description = "Client library for AI agent runtime communication over WebSocket"
 readme = "README.md"
 license = {"text" = "FSL"}

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/__init__.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/__init__.py
@@ -23,6 +23,7 @@ from .types import (
     TextResult,
     StructuredOutputResult,
     AssistantMessageInterface,
+    CommandOutputMessageInterface,
     ArtifactUploadRequestMessageInterface,
     ArtifactUploadResponseMessageInterface,
     ErrorMessageInterface,
@@ -31,6 +32,7 @@ from .types import (
     EndSessionConfirmMessage,
     ArtifactUploadResult,
     OnAssistantMessageCallback,
+    OnCommandOutputCallback,
     OnArtifactUploadRequestCallback,
 )
 
@@ -59,6 +61,7 @@ __all__ = [
     "TextResult",
     "StructuredOutputResult",
     "AssistantMessageInterface",
+    "CommandOutputMessageInterface",
     "ArtifactUploadRequestMessageInterface",
     "ArtifactUploadResponseMessageInterface",
     "ErrorMessageInterface",
@@ -67,5 +70,6 @@ __all__ = [
     "EndSessionConfirmMessage",
     "ArtifactUploadResult",
     "OnAssistantMessageCallback",
+    "OnCommandOutputCallback",
     "OnArtifactUploadRequestCallback",
 ]

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
@@ -18,6 +18,7 @@ from .types import (
     CommandExecutionResult,
     CommandInterface,
     AssistantMessageInterface,
+    CommandOutputMessageInterface,
     ArtifactUploadRequestMessageInterface,
     ArtifactUploadResponseMessageInterface,
     OnArtifactUploadRequestCallback,
@@ -90,6 +91,7 @@ async def _run_request_loop(
     terminal_message_type: str,
     result_cls,
     on_assistant_message,
+    on_command_output,
     on_artifact_upload_request,
     cancelled_message: str,
     logger: logging.Logger,
@@ -147,6 +149,12 @@ async def _run_request_loop(
             if on_assistant_message is not None:
                 assistant = AssistantMessageInterface.model_validate(message)
                 await on_assistant_message(assistant)
+            continue
+
+        if message_interface.message_type == "command_output_message":
+            if on_command_output is not None:
+                output = CommandOutputMessageInterface.model_validate(message)
+                await on_command_output(output)
             continue
 
         if message_interface.message_type == "artifact_upload_request_message":
@@ -227,6 +235,7 @@ class RuntimeUseSession:
                             terminal_message_type="result_message",
                             result_cls=ResultMessageInterface,
                             on_assistant_message=options.on_assistant_message,
+                            on_command_output=options.on_command_output,
                             on_artifact_upload_request=options.on_artifact_upload_request,
                             cancelled_message="Query was cancelled",
                             logger=logger,
@@ -265,6 +274,7 @@ class RuntimeUseSession:
                             terminal_message_type="command_execution_result_message",
                             result_cls=CommandExecutionResultMessageInterface,
                             on_assistant_message=options.on_assistant_message,
+                            on_command_output=options.on_command_output,
                             on_artifact_upload_request=options.on_artifact_upload_request,
                             cancelled_message="Command execution was cancelled",
                             logger=logger,
@@ -434,6 +444,7 @@ class RuntimeUseClient:
                     terminal_message_type="result_message",
                     result_cls=ResultMessageInterface,
                     on_assistant_message=options.on_assistant_message,
+                    on_command_output=options.on_command_output,
                     on_artifact_upload_request=options.on_artifact_upload_request,
                     cancelled_message="Query was cancelled",
                     logger=logger,
@@ -482,6 +493,7 @@ class RuntimeUseClient:
                     terminal_message_type="command_execution_result_message",
                     result_cls=CommandExecutionResultMessageInterface,
                     on_assistant_message=options.on_assistant_message,
+                    on_command_output=options.on_command_output,
                     on_artifact_upload_request=options.on_artifact_upload_request,
                     cancelled_message="Command execution was cancelled",
                     logger=logger,

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
@@ -111,6 +111,16 @@ async def _run_request_loop(
     error_to_raise: AgentRuntimeError | None = None
 
     async for message in message_iter:
+        # Hot path: command output chunks bypass Pydantic validation entirely.
+        # The runtime owns this internal wire format, and chatty commands can
+        # emit thousands of chunks per request.
+        if message.get("message_type") == "command_output_message":
+            if not abort_event.is_set() and on_command_output is not None:
+                await on_command_output(
+                    CommandOutputMessageInterface.model_construct(**message)
+                )
+            continue
+
         try:
             message_interface = AgentRuntimeMessageInterface.model_validate(message)
         except pydantic.ValidationError:
@@ -149,12 +159,6 @@ async def _run_request_loop(
             if on_assistant_message is not None:
                 assistant = AssistantMessageInterface.model_validate(message)
                 await on_assistant_message(assistant)
-            continue
-
-        if message_interface.message_type == "command_output_message":
-            if on_command_output is not None:
-                output = CommandOutputMessageInterface.model_validate(message)
-                await on_command_output(output)
             continue
 
         if message_interface.message_type == "artifact_upload_request_message":

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/types.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/types.py
@@ -10,6 +10,7 @@ class AgentRuntimeMessageInterface(BaseModel):
     message_type: Literal[
         "result_message",
         "assistant_message",
+        "command_output_message",
         "artifact_upload_request_message",
         "error_message",
         "command_execution_result_message",
@@ -76,6 +77,22 @@ class ResultMessageInterface(AgentRuntimeMessageInterface):
 class AssistantMessageInterface(AgentRuntimeMessageInterface):
     message_type: Literal["assistant_message"]
     text_blocks: list[str]
+
+
+class CommandOutputMessageInterface(AgentRuntimeMessageInterface):
+    """Wire-format message carrying a single chunk of command output.
+
+    Emitted by the runtime for stdout/stderr from commands run via
+    ``pre_agent_invocation_commands``, ``post_agent_invocation_commands``,
+    or :meth:`RuntimeUseClient.execute_commands`. The ``stream`` field
+    distinguishes stdout from stderr, and ``command`` carries the original
+    command string for context.
+    """
+
+    message_type: Literal["command_output_message"]
+    stream: Literal["stdout", "stderr"]
+    text: str
+    command: str
 
 
 class ArtifactUploadRequestMessageInterface(AgentRuntimeMessageInterface):
@@ -146,6 +163,7 @@ class ArtifactUploadResult(BaseModel):
 
 
 OnAssistantMessageCallback = Callable[[AssistantMessageInterface], Awaitable[None]]
+OnCommandOutputCallback = Callable[[CommandOutputMessageInterface], Awaitable[None]]
 OnArtifactUploadRequestCallback = Callable[
     [ArtifactUploadRequestMessageInterface], Awaitable[ArtifactUploadResult]
 ]
@@ -185,6 +203,8 @@ class QueryOptions:
 
     #: Called for each assistant (intermediate) message streamed back.
     on_assistant_message: OnAssistantMessageCallback | None = None
+    #: Called for each chunk of stdout/stderr emitted by pre/post commands.
+    on_command_output: OnCommandOutputCallback | None = None
     #: Called when the runtime requests an artifact upload URL.
     on_artifact_upload_request: OnArtifactUploadRequestCallback | None = None
     #: Overall timeout in seconds for the query. ``None`` means no limit.
@@ -217,6 +237,8 @@ class ExecuteCommandsOptions:
     ) = None
     #: Called for each assistant (intermediate) message streamed back.
     on_assistant_message: OnAssistantMessageCallback | None = None
+    #: Called for each chunk of stdout/stderr emitted by the commands.
+    on_command_output: OnCommandOutputCallback | None = None
     #: Called when the runtime requests an artifact upload URL.
     on_artifact_upload_request: OnArtifactUploadRequestCallback | None = None
     #: Overall timeout in seconds. ``None`` means no limit.

--- a/packages/runtimeuse-client-python/test/e2e/test_e2e.py
+++ b/packages/runtimeuse-client-python/test/e2e/test_e2e.py
@@ -17,6 +17,7 @@ from src.runtimeuse_client import (
     TextResult,
     StructuredOutputResult,
     AssistantMessageInterface,
+    CommandOutputMessageInterface,
     ArtifactUploadRequestMessageInterface,
     ArtifactUploadResult,
     AgentRuntimeError,
@@ -120,9 +121,9 @@ class TestPrePostCommands:
     async def test_pre_command_output_streamed(
         self, client: RuntimeUseClient, make_query_options
     ):
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         result = await client.query(
@@ -131,21 +132,20 @@ class TestPrePostCommands:
                 pre_agent_invocation_commands=[
                     CommandInterface(command="echo pre-sentinel")
                 ],
-                on_assistant_message=on_msg,
+                on_command_output=on_output,
             ),
         )
 
         assert isinstance(result.data, TextResult)
         assert result.data.text == "hello"
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert any("pre-sentinel" in t for t in all_text)
+        assert any("pre-sentinel" in msg.text for msg in received)
 
     async def test_post_command_output_streamed(
         self, client: RuntimeUseClient, make_query_options
     ):
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         result = await client.query(
@@ -154,21 +154,20 @@ class TestPrePostCommands:
                 post_agent_invocation_commands=[
                     CommandInterface(command="echo post-sentinel")
                 ],
-                on_assistant_message=on_msg,
+                on_command_output=on_output,
             ),
         )
 
         assert isinstance(result.data, TextResult)
         assert result.data.text == "hello"
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert any("post-sentinel" in t for t in all_text)
+        assert any("post-sentinel" in msg.text for msg in received)
 
     async def test_pre_and_post_commands_both_run(
         self, client: RuntimeUseClient, make_query_options
     ):
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         result = await client.query(
@@ -180,22 +179,21 @@ class TestPrePostCommands:
                 post_agent_invocation_commands=[
                     CommandInterface(command="echo post-sentinel")
                 ],
-                on_assistant_message=on_msg,
+                on_command_output=on_output,
             ),
         )
 
         assert isinstance(result.data, TextResult)
         assert result.data.text == "hello"
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert any("pre-sentinel" in t for t in all_text)
-        assert any("post-sentinel" in t for t in all_text)
+        assert any("pre-sentinel" in msg.text for msg in received)
+        assert any("post-sentinel" in msg.text for msg in received)
 
     async def test_pre_command_with_cwd(
         self, client: RuntimeUseClient, make_query_options
     ):
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         await client.query(
@@ -204,19 +202,18 @@ class TestPrePostCommands:
                 pre_agent_invocation_commands=[
                     CommandInterface(command="pwd", cwd="/tmp")
                 ],
-                on_assistant_message=on_msg,
+                on_command_output=on_output,
             ),
         )
 
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert any("/tmp" in t for t in all_text)
+        assert any("/tmp" in msg.text for msg in received)
 
     async def test_post_command_with_cwd(
         self, client: RuntimeUseClient, make_query_options
     ):
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         await client.query(
@@ -225,12 +222,11 @@ class TestPrePostCommands:
                 post_agent_invocation_commands=[
                     CommandInterface(command="pwd", cwd="/tmp")
                 ],
-                on_assistant_message=on_msg,
+                on_command_output=on_output,
             ),
         )
 
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert any("/tmp" in t for t in all_text)
+        assert any("/tmp" in msg.text for msg in received)
 
     async def test_failed_pre_command_raises_error(
         self, client: RuntimeUseClient, make_query_options
@@ -473,9 +469,9 @@ class TestFullInvocationLifecycle:
         artifacts_dir = f"/tmp/art-lifecycle-{uuid4()}"
         os.makedirs(artifacts_dir, exist_ok=True)
 
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         async def on_artifact(
@@ -504,7 +500,7 @@ class TestFullInvocationLifecycle:
                 ],
                 artifacts_dir=artifacts_dir,
                 on_artifact_upload_request=on_artifact,
-                on_assistant_message=on_msg,
+                on_command_output=on_output,
                 timeout=20,
             ),
         )
@@ -512,11 +508,10 @@ class TestFullInvocationLifecycle:
         assert isinstance(result.data, TextResult)
         assert result.data.text == f"wrote {artifacts_dir}/output.txt"
 
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert any("runtime-payload" in t for t in all_text), (
+        assert any("runtime-payload" in msg.text for msg in received), (
             "pre-command should have cat'd the downloaded file"
         )
-        assert any("lifecycle-done" in t for t in all_text), (
+        assert any("lifecycle-done" in msg.text for msg in received), (
             "post-command should have run after the agent"
         )
 
@@ -529,9 +524,9 @@ class TestSecretsRedaction:
     async def test_secret_redacted_from_command_output(
         self, client: RuntimeUseClient, make_query_options
     ):
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         result = await client.query(
@@ -541,14 +536,13 @@ class TestSecretsRedaction:
                 pre_agent_invocation_commands=[
                     CommandInterface(command="echo super-secret-value")
                 ],
-                on_assistant_message=on_msg,
+                on_command_output=on_output,
             ),
         )
 
         assert isinstance(result.data, TextResult)
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert not any("super-secret-value" in t for t in all_text)
-        assert any("[REDACTED]" in t for t in all_text)
+        assert not any("super-secret-value" in msg.text for msg in received)
+        assert any("[REDACTED]" in msg.text for msg in received)
 
     async def test_secret_redacted_from_assistant_message(
         self, client: RuntimeUseClient, make_query_options
@@ -643,20 +637,19 @@ class TestExecuteCommands:
     async def test_command_output_streamed_via_callback(
         self, client: RuntimeUseClient, make_execute_commands_options
     ):
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         await client.execute_commands(
             commands=[CommandInterface(command="echo streamed-sentinel")],
             options=make_execute_commands_options(
-                on_assistant_message=on_msg, timeout=10
+                on_command_output=on_output, timeout=10
             ),
         )
 
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert any("streamed-sentinel" in t for t in all_text)
+        assert any("streamed-sentinel" in msg.text for msg in received)
 
     async def test_failed_command_returns_exit_code(
         self, client: RuntimeUseClient, make_execute_commands_options
@@ -707,50 +700,48 @@ class TestExecuteCommands:
     async def test_command_with_cwd(
         self, client: RuntimeUseClient, make_execute_commands_options
     ):
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         result = await client.execute_commands(
             commands=[CommandInterface(command="pwd", cwd="/tmp")],
             options=make_execute_commands_options(
-                on_assistant_message=on_msg, timeout=10
+                on_command_output=on_output, timeout=10
             ),
         )
 
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert any("/tmp" in t for t in all_text)
+        assert any("/tmp" in msg.text for msg in received)
         assert result.results[0].stdout is not None
         assert "/tmp" in result.results[0].stdout
 
     async def test_secrets_redacted_from_output(
         self, client: RuntimeUseClient, make_execute_commands_options
     ):
-        received: list[AssistantMessageInterface] = []
+        received: list[CommandOutputMessageInterface] = []
 
-        async def on_msg(msg: AssistantMessageInterface):
+        async def on_output(msg: CommandOutputMessageInterface):
             received.append(msg)
 
         await client.execute_commands(
             commands=[CommandInterface(command="echo my-secret-token")],
             options=make_execute_commands_options(
                 secrets_to_redact=["my-secret-token"],
-                on_assistant_message=on_msg,
+                on_command_output=on_output,
                 timeout=10,
             ),
         )
 
-        all_text = [block for msg in received for block in msg.text_blocks]
-        assert not any("my-secret-token" in t for t in all_text)
-        assert any("[REDACTED]" in t for t in all_text)
+        assert not any("my-secret-token" in msg.text for msg in received)
+        assert any("[REDACTED]" in msg.text for msg in received)
 
     async def test_cancellation(
         self, ws_url: str, make_execute_commands_options
     ):
         client = RuntimeUseClient(ws_url=ws_url)
 
-        async def abort_on_first(msg: AssistantMessageInterface):
+        async def abort_on_first(msg: CommandOutputMessageInterface):
             client.abort()
 
         with pytest.raises((CancelledException, TimeoutError)):
@@ -761,7 +752,7 @@ class TestExecuteCommands:
                     ),
                 ],
                 options=make_execute_commands_options(
-                    on_assistant_message=abort_on_first, timeout=5
+                    on_command_output=abort_on_first, timeout=5
                 ),
             )
 

--- a/packages/runtimeuse-client-python/test/test_client.py
+++ b/packages/runtimeuse-client-python/test/test_client.py
@@ -14,6 +14,7 @@ from src.runtimeuse_client import (
     TextResult,
     StructuredOutputResult,
     AssistantMessageInterface,
+    CommandOutputMessageInterface,
     ArtifactUploadRequestMessageInterface,
     ArtifactUploadResult,
     AgentRuntimeError,
@@ -147,6 +148,87 @@ class TestAssistantMessage:
             prompt=DEFAULT_PROMPT,
             options=query_options,
         )
+
+
+# ---------------------------------------------------------------------------
+# Command output message
+# ---------------------------------------------------------------------------
+
+
+class TestCommandOutputMessage:
+    @pytest.mark.asyncio
+    async def test_stdout_dispatched_to_on_command_output(
+        self, fake_transport, make_query_options
+    ):
+        stdout_msg = {
+            "message_type": "command_output_message",
+            "stream": "stdout",
+            "text": "hello\n",
+            "command": "echo hello",
+        }
+        transport, client = fake_transport([stdout_msg, TEXT_RESULT_MSG])
+        on_output = AsyncMock()
+
+        await client.query(
+            prompt=DEFAULT_PROMPT,
+            options=make_query_options(on_command_output=on_output),
+        )
+
+        on_output.assert_awaited_once()
+        received = on_output.call_args[0][0]
+        assert isinstance(received, CommandOutputMessageInterface)
+        assert received.stream == "stdout"
+        assert received.text == "hello\n"
+        assert received.command == "echo hello"
+
+    @pytest.mark.asyncio
+    async def test_stderr_dispatched_to_on_command_output(
+        self, fake_transport, make_execute_commands_options
+    ):
+        stderr_msg = {
+            "message_type": "command_output_message",
+            "stream": "stderr",
+            "text": "boom\n",
+            "command": "false",
+        }
+        result_msg = {
+            "message_type": "command_execution_result_message",
+            "results": [{"command": "false", "exit_code": 1}],
+        }
+        transport, client = fake_transport([stderr_msg, result_msg])
+        on_output = AsyncMock()
+
+        await client.execute_commands(
+            commands=[CommandInterface(command="false")],
+            options=make_execute_commands_options(on_command_output=on_output),
+        )
+
+        on_output.assert_awaited_once()
+        received = on_output.call_args[0][0]
+        assert received.stream == "stderr"
+        assert received.text == "boom\n"
+        assert received.command == "false"
+
+    @pytest.mark.asyncio
+    async def test_command_output_ignored_without_callback(
+        self, fake_transport, query_options
+    ):
+        stdout_msg = {
+            "message_type": "command_output_message",
+            "stream": "stdout",
+            "text": "ignored\n",
+            "command": "echo ignored",
+        }
+        transport, client = fake_transport([stdout_msg, TEXT_RESULT_MSG])
+
+        # Without on_command_output, the loop should silently skip the chunk
+        # and still consume the terminal cleanly.
+        result = await client.query(
+            prompt=DEFAULT_PROMPT,
+            options=query_options,
+        )
+
+        assert isinstance(result, QueryResult)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/runtimeuse-client-python/uv.lock
+++ b/packages/runtimeuse-client-python/uv.lock
@@ -1618,7 +1618,7 @@ wheels = [
 
 [[package]]
 name = "runtimeuse-client"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/packages/runtimeuse/README.md
+++ b/packages/runtimeuse/README.md
@@ -178,7 +178,7 @@ When a client sends an `invocation_message`, the session:
 
 ### Command-Only Execution (no agent)
 
-The session also accepts a `command_execution_message` instead of an `invocation_message`. This runs `pre_execution_downloadables` and the provided commands, streams output as `assistant_message`s, and returns a `command_execution_result_message` with per-command exit codes. The agent handler never gets invoked. Each command can specify its own `env` and `cwd`. See the [Python client docs](../runtimeuse-client-python/README.md#command-only-execution) for usage.
+The session also accepts a `command_execution_message` instead of an `invocation_message`. This runs `pre_execution_downloadables` and the provided commands, streams stdout/stderr as `command_output_message`s (each carrying `stream`, `text`, and `command`), and returns a `command_execution_result_message` with per-command exit codes. The agent handler never gets invoked. Each command can specify its own `env` and `cwd`. See the [Python client docs](../runtimeuse-client-python/README.md#command-only-execution) for usage.
 
 ## Environment Variables
 

--- a/packages/runtimeuse/package-lock.json
+++ b/packages/runtimeuse/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runtimeuse",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runtimeuse",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "FSL",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.73",

--- a/packages/runtimeuse/package.json
+++ b/packages/runtimeuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimeuse",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "AI agent runtime with WebSocket protocol, artifact handling, and secret management",
   "license": "FSL",
   "type": "module",

--- a/packages/runtimeuse/src/index.ts
+++ b/packages/runtimeuse/src/index.ts
@@ -46,6 +46,7 @@ export type {
   CancelMessage,
   ResultMessage,
   AssistantMessage,
+  CommandOutputMessage,
   ArtifactUploadRequestMessage,
   ArtifactUploadResponseMessage,
   ErrorMessage,

--- a/packages/runtimeuse/src/invocation-runner.test.ts
+++ b/packages/runtimeuse/src/invocation-runner.test.ts
@@ -184,7 +184,7 @@ describe("InvocationRunner", () => {
     );
   });
 
-  it("forwards command stdout and stderr through assistant messages", async () => {
+  it("forwards command stdout and stderr as command_output_message with stream and command", async () => {
     mockExecute.mockImplementation(async (options) => {
       options.onStdout?.("stdout data");
       options.onStderr?.("stderr data");
@@ -198,12 +198,16 @@ describe("InvocationRunner", () => {
     await runner.run(message);
 
     expect(send).toHaveBeenCalledWith({
-      message_type: "assistant_message",
-      text_blocks: ["stdout data"],
+      message_type: "command_output_message",
+      stream: "stdout",
+      text: "stdout data",
+      command: "echo hello",
     });
     expect(send).toHaveBeenCalledWith({
-      message_type: "assistant_message",
-      text_blocks: ["stderr data"],
+      message_type: "command_output_message",
+      stream: "stderr",
+      text: "stderr data",
+      command: "echo hello",
     });
   });
 
@@ -457,7 +461,7 @@ describe("InvocationRunner.runCommandsOnly", () => {
     });
   });
 
-  it("forwards stdout and stderr through assistant messages", async () => {
+  it("forwards stdout and stderr as command_output_message with stream and command", async () => {
     mockExecute.mockImplementation(async (options) => {
       options.onStdout?.("stdout data");
       options.onStderr?.("stderr data");
@@ -469,12 +473,16 @@ describe("InvocationRunner.runCommandsOnly", () => {
     await runner.runCommandsOnly(message);
 
     expect(send).toHaveBeenCalledWith({
-      message_type: "assistant_message",
-      text_blocks: ["stdout data"],
+      message_type: "command_output_message",
+      stream: "stdout",
+      text: "stdout data",
+      command: "echo hello",
     });
     expect(send).toHaveBeenCalledWith({
-      message_type: "assistant_message",
-      text_blocks: ["stderr data"],
+      message_type: "command_output_message",
+      stream: "stderr",
+      text: "stderr data",
+      command: "echo hello",
     });
   });
 

--- a/packages/runtimeuse/src/invocation-runner.ts
+++ b/packages/runtimeuse/src/invocation-runner.ts
@@ -122,9 +122,19 @@ export class InvocationRunner {
       logger,
       abortController,
       onStdout: (stdout) =>
-        send({ message_type: "assistant_message", text_blocks: [stdout] }),
+        send({
+          message_type: "command_output_message",
+          stream: "stdout",
+          text: stdout,
+          command: command.command,
+        }),
       onStderr: (stderr) =>
-        send({ message_type: "assistant_message", text_blocks: [stderr] }),
+        send({
+          message_type: "command_output_message",
+          stream: "stderr",
+          text: stderr,
+          command: command.command,
+        }),
     });
 
     const result = await handler.execute();
@@ -172,9 +182,19 @@ export class InvocationRunner {
         logger,
         abortController,
         onStdout: (stdout) =>
-          send({ message_type: "assistant_message", text_blocks: [stdout] }),
+          send({
+            message_type: "command_output_message",
+            stream: "stdout",
+            text: stdout,
+            command: command.command,
+          }),
         onStderr: (stderr) =>
-          send({ message_type: "assistant_message", text_blocks: [stderr] }),
+          send({
+            message_type: "command_output_message",
+            stream: "stderr",
+            text: stderr,
+            command: command.command,
+          }),
       });
 
       const result = await handler.execute();

--- a/packages/runtimeuse/src/types.ts
+++ b/packages/runtimeuse/src/types.ts
@@ -66,6 +66,13 @@ interface AssistantMessage {
   text_blocks: string[];
 }
 
+interface CommandOutputMessage {
+  message_type: "command_output_message";
+  stream: "stdout" | "stderr";
+  text: string;
+  command: string;
+}
+
 interface ArtifactUploadRequestMessage {
   message_type: "artifact_upload_request_message";
   filename: string;
@@ -93,6 +100,7 @@ interface EndSessionConfirmMessage {
 type OutgoingMessage =
   | ResultMessage
   | AssistantMessage
+  | CommandOutputMessage
   | ArtifactUploadRequestMessage
   | ErrorMessage
   | CommandExecutionResultMessage
@@ -116,6 +124,7 @@ export type {
   EndSessionMessage,
   ResultMessage,
   AssistantMessage,
+  CommandOutputMessage,
   ArtifactUploadRequestMessage,
   ArtifactUploadResponseMessage,
   ErrorMessage,


### PR DESCRIPTION
## Summary

- Introduces a `command_output_message` wire type so command stdout/stderr is no longer conflated with agent `assistant_message` text. Each chunk carries `stream` (`"stdout"`/`"stderr"`), `text`, and the originating `command`.
- Python client adds `on_command_output` to `QueryOptions` and `ExecuteCommandsOptions`. `on_assistant_message` continues to carry agent text only.
- Both `runtimeuse` and `runtimeuse-client` bumped 0.13.0 → 0.14.0.

## Why

When pre/post commands or `execute_commands` produce output, callers currently can't tell command stdout/stderr apart from agent reasoning, can't tell stdout from stderr, and can't tie a chunk back to the command that produced it. This blocks per-command logging policies (e.g. routing setup-command output somewhere different from agent text).

## Test plan

- [x] TS: `npm test` in `packages/runtimeuse` — 143/143 pass
- [x] TS: `npm run typecheck` — clean
- [x] Python: `uv run pytest test/test_client.py -q` — 47/47 pass (3 new tests in `TestCommandOutputMessage`)
- [x] Imports / instantiation smoke-test of `CommandOutputMessageInterface`, `OnCommandOutputCallback`, `on_command_output` field

## Notes

- `assistant_message` is unchanged and still used by agent handlers via `MessageSender.sendAssistantMessage`.
- Old clients that only listen on `on_assistant_message` will no longer see command output (they'd previously get it disguised as agent text). That's the intended cleanup; pair any consumer upgrade with wiring `on_command_output`.
- `silent` flag is not added — visibility decisions move to the receiver via `on_command_output`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the wire protocol and client callback surface for streamed command output; older clients listening only to `assistant_message` will stop seeing pre/post/command-only output unless updated.
> 
> **Overview**
> Introduces a new `command_output_message` wire type so stdout/stderr from pre/post-invocation commands and `execute_commands` is no longer sent as `assistant_message`, and now includes `stream` (stdout/stderr), `text`, and originating `command`.
> 
> Updates the Python client to handle and expose this via a new `on_command_output` callback (with a lightweight hot-path dispatch), adds `CommandOutputMessageInterface`/`OnCommandOutputCallback`, and adjusts tests/examples/docs accordingly. Bumps both `runtimeuse` and `runtimeuse-client` versions to `0.14.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c28a91b8f1a380758fabc1176603866f6fda24e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->