### PR TITLE
Support multiple artifact directories per invocation

### DIFF
--- a/docs/content/docs/python-client.mdx
+++ b/docs/content/docs/python-client.mdx
@@ -148,7 +148,7 @@ The runtime downloads and extracts the file before handing control to the agent.
 
 ## Upload Artifacts
 
-When the runtime requests an artifact upload, return a presigned URL and content type from `on_artifact_upload_request`. Set `artifacts_dir` to tell the runtime which sandbox directory contains the files to upload - both options must be provided together.
+When the runtime requests an artifact upload, return a presigned URL and content type from `on_artifact_upload_request`. Set `artifacts_dirs` to a list of sandbox directories the runtime should watch for files to upload - both options must be provided together. Pass multiple paths to watch several directories within a single invocation; each may carry its own `.artifactignore`.
 
 ```python
 from runtimeuse_client import ArtifactUploadResult
@@ -163,11 +163,11 @@ async def on_artifact_upload_request(request) -> ArtifactUploadResult:
 
 
 result = await client.query(
-    prompt="Generate a report and save it as report.txt.",
+    prompt="Generate a report and a screenshot.",
     options=QueryOptions(
         system_prompt="You are a helpful assistant.",
         model="gpt-4.1",
-        artifacts_dir="/runtimeuse/output",
+        artifacts_dirs=["/runtimeuse/output", "/runtimeuse/screenshots"],
         on_artifact_upload_request=on_artifact_upload_request,
     ),
 )

--- a/packages/runtimeuse-client-python/README.md
+++ b/packages/runtimeuse-client-python/README.md
@@ -175,7 +175,7 @@ async def on_artifact(request: ArtifactUploadRequestMessageInterface) -> Artifac
     return ArtifactUploadResult(presigned_url=presigned_url, content_type=content_type)
 ```
 
-When using artifact uploads, set both `artifacts_dir` and `on_artifact_upload_request` in `QueryOptions`; the client validates that they are provided together.
+When using artifact uploads, set both `artifacts_dirs` (a list of sandbox directories to watch) and `on_artifact_upload_request` in `QueryOptions`; the client validates that they are provided together. Pass multiple paths to watch several directories within a single invocation.
 
 ### Cancellation
 

--- a/packages/runtimeuse-client-python/pyproject.toml
+++ b/packages/runtimeuse-client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "runtimeuse-client"
-version = "0.14.1"
+version = "0.14.2"
 description = "Client library for AI agent runtime communication over WebSocket"
 readme = "README.md"
 license = {"text" = "FSL"}

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
@@ -42,7 +42,7 @@ def _build_invocation(prompt: str, options: QueryOptions) -> InvocationMessage:
         source_id=options.source_id,
         agent_env=options.agent_env,
         secrets_to_redact=options.secrets_to_redact,
-        artifacts_dir=options.artifacts_dir,
+        artifacts_dirs=options.artifacts_dirs or None,
         pre_agent_invocation_commands=options.pre_agent_invocation_commands,
         post_agent_invocation_commands=options.post_agent_invocation_commands,
         pre_agent_downloadables=options.pre_agent_downloadables,
@@ -57,7 +57,7 @@ def _build_command_execution(
         source_id=options.source_id,
         secrets_to_redact=options.secrets_to_redact,
         commands=commands,
-        artifacts_dir=options.artifacts_dir,
+        artifacts_dirs=options.artifacts_dirs or None,
         pre_execution_downloadables=options.pre_execution_downloadables,
     )
 

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/types.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/types.py
@@ -39,7 +39,7 @@ class InvocationMessage(BaseModel):
     agent_env: dict[str, str] | None = None
     output_format_json_schema_str: str | None = None
     secrets_to_redact: list[str] = Field(default_factory=list)
-    artifacts_dir: str | None = None
+    artifacts_dirs: list[str] | None = None
     pre_agent_invocation_commands: list[CommandInterface] | None = None
     post_agent_invocation_commands: list[CommandInterface] | None = None
     model: str
@@ -139,7 +139,7 @@ class CommandExecutionMessage(BaseModel):
     source_id: str | None = None
     secrets_to_redact: list[str] = Field(default_factory=list)
     commands: list[CommandInterface]
-    artifacts_dir: str | None = None
+    artifacts_dirs: list[str] | None = None
     pre_execution_downloadables: (
         list[RuntimeEnvironmentDownloadableInterface] | None
     ) = None
@@ -176,6 +176,16 @@ OnArtifactUploadRequestCallback = Callable[
 ]
 
 
+def _validate_artifact_pairing(
+    artifacts_dirs: list[str] | None,
+    callback: OnArtifactUploadRequestCallback | None,
+) -> None:
+    if bool(artifacts_dirs) != (callback is not None):
+        raise ValueError(
+            "artifacts_dirs and on_artifact_upload_request must be specified together"
+        )
+
+
 @dataclass
 class QueryOptions:
     """Options for :meth:`RuntimeUseClient.query`.
@@ -199,8 +209,10 @@ class QueryOptions:
     agent_env: dict[str, str] | None = None
     #: Secret values to redact from agent logs and responses.
     secrets_to_redact: list[str] = field(default_factory=list)
-    #: Directory inside the runtime environment where artifacts are written.
-    artifacts_dir: str | None = None
+    #: Directories inside the runtime environment where artifacts are written.
+    #: Each directory is watched independently and may carry its own
+    #: ``.artifactignore``. An empty list is treated the same as ``None``.
+    artifacts_dirs: list[str] | None = None
     #: Commands to run in the runtime environment before the agent starts.
     pre_agent_invocation_commands: list[CommandInterface] | None = None
     #: Commands to run in the runtime environment after the agent finishes.
@@ -226,12 +238,9 @@ class QueryOptions:
     logger: logging.Logger | None = None
 
     def __post_init__(self) -> None:
-        has_dir = self.artifacts_dir is not None
-        has_cb = self.on_artifact_upload_request is not None
-        if has_dir != has_cb:
-            raise ValueError(
-                "artifacts_dir and on_artifact_upload_request must be specified together"
-            )
+        _validate_artifact_pairing(
+            self.artifacts_dirs, self.on_artifact_upload_request
+        )
 
 
 @dataclass
@@ -242,8 +251,10 @@ class ExecuteCommandsOptions:
     secrets_to_redact: list[str] = field(default_factory=list)
     #: Caller-defined identifier for tracing/logging purposes.
     source_id: str | None = None
-    #: Directory inside the runtime environment where artifacts are written.
-    artifacts_dir: str | None = None
+    #: Directories inside the runtime environment where artifacts are written.
+    #: Each directory is watched independently and may carry its own
+    #: ``.artifactignore``. An empty list is treated the same as ``None``.
+    artifacts_dirs: list[str] | None = None
     #: Files to download into the runtime environment before commands run.
     pre_execution_downloadables: (
         list[RuntimeEnvironmentDownloadableInterface] | None
@@ -266,9 +277,6 @@ class ExecuteCommandsOptions:
     logger: logging.Logger | None = None
 
     def __post_init__(self) -> None:
-        has_dir = self.artifacts_dir is not None
-        has_cb = self.on_artifact_upload_request is not None
-        if has_dir != has_cb:
-            raise ValueError(
-                "artifacts_dir and on_artifact_upload_request must be specified together"
-            )
+        _validate_artifact_pairing(
+            self.artifacts_dirs, self.on_artifact_upload_request
+        )

--- a/packages/runtimeuse-client-python/test/e2e/test_e2e.py
+++ b/packages/runtimeuse-client-python/test/e2e/test_e2e.py
@@ -275,7 +275,7 @@ class TestArtifacts:
         result = await client.query(
             prompt=f"WRITE_FILE:{artifacts_dir}/test.txt test-content",
             options=make_query_options(
-                artifacts_dir=artifacts_dir,
+                artifacts_dirs=[artifacts_dir],
                 on_artifact_upload_request=on_artifact,
                 timeout=15,
             ),
@@ -325,7 +325,7 @@ class TestArtifactUploadIntegration:
         result = await client.query(
             prompt=f"WRITE_FILE:{artifacts_dir}/hello.txt some-content",
             options=make_query_options(
-                artifacts_dir=artifacts_dir,
+                artifacts_dirs=[artifacts_dir],
                 on_artifact_upload_request=on_artifact,
                 timeout=15,
             ),
@@ -334,6 +334,44 @@ class TestArtifactUploadIntegration:
         assert isinstance(result.data, TextResult)
         assert result.data.text == f"wrote {artifacts_dir}/hello.txt"
         assert uploads.get("hello.txt") == b"some-content"
+
+    async def test_multiple_artifacts_dirs_in_single_invocation(
+        self, client: RuntimeUseClient, make_query_options, http_server
+    ):
+        """A single invocation declares two artifact directories; files in
+        either should be picked up and uploaded."""
+        base_url, _files, uploads = http_server
+        dir_a = f"/tmp/test-art-multi-a-{uuid4()}"
+        dir_b = f"/tmp/test-art-multi-b-{uuid4()}"
+        os.makedirs(dir_a, exist_ok=True)
+        os.makedirs(dir_b, exist_ok=True)
+
+        async def on_artifact(
+            req: ArtifactUploadRequestMessageInterface,
+        ) -> ArtifactUploadResult:
+            return ArtifactUploadResult(
+                presigned_url=f"{base_url}/uploads/{req.filename}",
+                content_type="text/plain",
+            )
+
+        result = await client.query(
+            prompt=f"WRITE_FILE:{dir_b}/from-agent.txt agent-content",
+            options=make_query_options(
+                pre_agent_invocation_commands=[
+                    CommandInterface(
+                        command=f"printf 'pre-content' > {dir_a}/from-pre.txt"
+                    ),
+                ],
+                artifacts_dirs=[dir_a, dir_b],
+                on_artifact_upload_request=on_artifact,
+                timeout=20,
+            ),
+        )
+
+        assert isinstance(result.data, TextResult)
+        assert result.data.text == f"wrote {dir_b}/from-agent.txt"
+        assert uploads.get("from-pre.txt") == b"pre-content"
+        assert uploads.get("from-agent.txt") == b"agent-content"
 
     async def test_multiple_artifacts_uploaded(
         self, ws_url: str, make_query_options, http_server
@@ -351,7 +389,7 @@ class TestArtifactUploadIntegration:
             )
 
         opts = dict(
-            artifacts_dir=artifacts_dir,
+            artifacts_dirs=[artifacts_dir],
             on_artifact_upload_request=on_artifact,
             timeout=15,
         )
@@ -498,7 +536,7 @@ class TestFullInvocationLifecycle:
                 post_agent_invocation_commands=[
                     CommandInterface(command="echo lifecycle-done")
                 ],
-                artifacts_dir=artifacts_dir,
+                artifacts_dirs=[artifacts_dir],
                 on_artifact_upload_request=on_artifact,
                 on_command_output=on_output,
                 timeout=20,

--- a/packages/runtimeuse-client-python/test/llm/test_claude_advanced.py
+++ b/packages/runtimeuse-client-python/test/llm/test_claude_advanced.py
@@ -122,7 +122,7 @@ class TestClaudeArtifactsS3:
             options=QueryOptions(
                 system_prompt="You are a helpful assistant. Execute tasks using tools.",
                 model=MODEL,
-                artifacts_dir=artifacts_dir,
+                artifacts_dirs=[artifacts_dir],
                 on_artifact_upload_request=on_artifact,
                 timeout=120,
             ),
@@ -203,7 +203,7 @@ class TestClaudeFullLifecycle:
                 post_agent_invocation_commands=[
                     CommandInterface(command="echo lifecycle-done")
                 ],
-                artifacts_dir=artifacts_dir,
+                artifacts_dirs=[artifacts_dir],
                 on_artifact_upload_request=on_artifact,
                 on_assistant_message=on_msg,
                 timeout=120,

--- a/packages/runtimeuse-client-python/test/llm/test_openai_advanced.py
+++ b/packages/runtimeuse-client-python/test/llm/test_openai_advanced.py
@@ -122,7 +122,7 @@ class TestOpenAIArtifactsS3:
             options=QueryOptions(
                 system_prompt="You are a helpful assistant. Execute tasks using tools.",
                 model=MODEL,
-                artifacts_dir=artifacts_dir,
+                artifacts_dirs=[artifacts_dir],
                 on_artifact_upload_request=on_artifact,
                 timeout=120,
             ),
@@ -203,7 +203,7 @@ class TestOpenAIFullLifecycle:
                 post_agent_invocation_commands=[
                     CommandInterface(command="echo lifecycle-done")
                 ],
-                artifacts_dir=artifacts_dir,
+                artifacts_dirs=[artifacts_dir],
                 on_artifact_upload_request=on_artifact,
                 on_assistant_message=on_msg,
                 timeout=120,

--- a/packages/runtimeuse-client-python/test/test_client.py
+++ b/packages/runtimeuse-client-python/test/test_client.py
@@ -301,7 +301,7 @@ class TestArtifactUpload:
         await client.query(
             prompt=DEFAULT_PROMPT,
             options=make_query_options(
-                artifacts_dir="/tmp/artifacts",
+                artifacts_dirs=["/tmp/artifacts"],
                 on_artifact_upload_request=on_artifact,
             ),
         )
@@ -317,6 +317,32 @@ class TestArtifactUpload:
         assert resp["filepath"] == "/tmp/screenshot.png"
         assert resp["presigned_url"] == "https://s3.example.com/presigned"
         assert resp["content_type"] == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_artifacts_dirs_forwarded_to_invocation(
+        self, fake_transport, make_query_options
+    ):
+        transport, client = fake_transport([TEXT_RESULT_MSG])
+
+        async def _on_artifact(_req):
+            return ArtifactUploadResult(
+                presigned_url="https://s3.example.com/x", content_type="text/plain"
+            )
+
+        await client.query(
+            prompt=DEFAULT_PROMPT,
+            options=make_query_options(
+                artifacts_dirs=["/tmp/one", "/tmp/two"],
+                on_artifact_upload_request=_on_artifact,
+            ),
+        )
+
+        invocation_msgs = [
+            m for m in transport.sent if m.get("message_type") == "invocation_message"
+        ]
+        assert len(invocation_msgs) == 1
+        assert invocation_msgs[0]["artifacts_dirs"] == ["/tmp/one", "/tmp/two"]
+        assert "artifacts_dir" not in invocation_msgs[0]
 
     @pytest.mark.asyncio
     async def test_artifact_upload_ignored_without_callback(
@@ -493,7 +519,7 @@ class TestTimeout:
             await client.query(
                 prompt=DEFAULT_PROMPT,
                 options=make_query_options(
-                    artifacts_dir="/tmp/artifacts",
+                    artifacts_dirs=["/tmp/artifacts"],
                     on_artifact_upload_request=slow_artifact,
                     artifact_upload_callback_timeout=0.05,
                     timeout=1,
@@ -773,9 +799,9 @@ class TestConstructor:
         transport, client = fake_transport([])
         assert client is not None
 
-    def test_artifacts_dir_requires_callback(self, make_query_options):
+    def test_artifacts_dirs_requires_callback(self, make_query_options):
         with pytest.raises(ValueError, match="must be specified together"):
-            make_query_options(artifacts_dir="/tmp/artifacts")
+            make_query_options(artifacts_dirs=["/tmp/artifacts"])
 
         async def _dummy_cb(req):
             return ArtifactUploadResult(
@@ -786,10 +812,30 @@ class TestConstructor:
             make_query_options(on_artifact_upload_request=_dummy_cb)
 
         opts = make_query_options(
-            artifacts_dir="/tmp/artifacts", on_artifact_upload_request=_dummy_cb
+            artifacts_dirs=["/tmp/artifacts"], on_artifact_upload_request=_dummy_cb
         )
-        assert opts.artifacts_dir == "/tmp/artifacts"
+        assert opts.artifacts_dirs == ["/tmp/artifacts"]
         assert opts.on_artifact_upload_request is _dummy_cb
+
+    def test_artifacts_dirs_empty_list_is_allowed_without_callback(
+        self, make_query_options
+    ):
+        # An empty list should behave the same as None — no pairing required.
+        opts = make_query_options(artifacts_dirs=[])
+        assert opts.artifacts_dirs == []
+        assert opts.on_artifact_upload_request is None
+
+    def test_artifacts_dirs_accepts_multiple(self, make_query_options):
+        async def _dummy_cb(req):
+            return ArtifactUploadResult(
+                presigned_url="https://example.com", content_type="text/plain"
+            )
+
+        opts = make_query_options(
+            artifacts_dirs=["/tmp/a", "/tmp/b"],
+            on_artifact_upload_request=_dummy_cb,
+        )
+        assert opts.artifacts_dirs == ["/tmp/a", "/tmp/b"]
 
 
 # ---------------------------------------------------------------------------
@@ -997,7 +1043,7 @@ class TestExecuteCommands:
         await client.execute_commands(
             commands=[CommandInterface(command="echo hello")],
             options=make_execute_commands_options(
-                artifacts_dir="/tmp/artifacts",
+                artifacts_dirs=["/tmp/artifacts"],
                 on_artifact_upload_request=on_artifact,
             ),
         )
@@ -1010,6 +1056,34 @@ class TestExecuteCommands:
         assert len(response_msgs) == 1
         assert response_msgs[0]["filename"] == "output.txt"
         assert response_msgs[0]["presigned_url"] == "https://s3.example.com/presigned"
+
+    @pytest.mark.asyncio
+    async def test_artifacts_dirs_forwarded_to_command_execution(
+        self, fake_transport, make_execute_commands_options
+    ):
+        transport, client = fake_transport([COMMAND_RESULT_MSG])
+
+        async def _on_artifact(_req):
+            return ArtifactUploadResult(
+                presigned_url="https://s3.example.com/x", content_type="text/plain"
+            )
+
+        await client.execute_commands(
+            commands=[CommandInterface(command="echo hello")],
+            options=make_execute_commands_options(
+                artifacts_dirs=["/tmp/one", "/tmp/two"],
+                on_artifact_upload_request=_on_artifact,
+            ),
+        )
+
+        cmd_msgs = [
+            m
+            for m in transport.sent
+            if m.get("message_type") == "command_execution_message"
+        ]
+        assert len(cmd_msgs) == 1
+        assert cmd_msgs[0]["artifacts_dirs"] == ["/tmp/one", "/tmp/two"]
+        assert "artifacts_dir" not in cmd_msgs[0]
 
     @pytest.mark.asyncio
     async def test_command_env_forwarded(
@@ -1056,7 +1130,7 @@ class TestExecuteCommands:
 
     def test_execute_commands_options_artifacts_validation(self):
         with pytest.raises(ValueError, match="must be specified together"):
-            ExecuteCommandsOptions(artifacts_dir="/tmp/artifacts")
+            ExecuteCommandsOptions(artifacts_dirs=["/tmp/artifacts"])
 
         async def _dummy_cb(req):
             return ArtifactUploadResult(
@@ -1065,6 +1139,9 @@ class TestExecuteCommands:
 
         with pytest.raises(ValueError, match="must be specified together"):
             ExecuteCommandsOptions(on_artifact_upload_request=_dummy_cb)
+
+        # Empty list should not require the callback.
+        ExecuteCommandsOptions(artifacts_dirs=[])
 
 
 # ---------------------------------------------------------------------------

--- a/packages/runtimeuse-client-python/uv.lock
+++ b/packages/runtimeuse-client-python/uv.lock
@@ -1618,7 +1618,7 @@ wheels = [
 
 [[package]]
 name = "runtimeuse-client"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/packages/runtimeuse/README.md
+++ b/packages/runtimeuse/README.md
@@ -189,7 +189,7 @@ Environment variables can be injected at two levels:
 
 ## Artifact Management
 
-Files written to the artifacts directory are automatically detected via `chokidar` file watching and uploaded through a presigned URL handshake with the client. The artifacts directory is specified per-invocation via the `artifacts_dir` field in the `InvocationMessage`.
+Files written to any of the artifact directories are automatically detected via `chokidar` file watching and uploaded through a presigned URL handshake with the client. The directories to watch are specified per-invocation via the `artifacts_dirs` field (a `string[]`) on the `InvocationMessage` or `CommandExecutionMessage`. The legacy singular `artifacts_dir` field is still accepted but deprecated.
 
 - The client provides the `content_type` for each artifact via the presigned URL response
 - `.artifactignore` files are respected (same syntax as `.gitignore`)

--- a/packages/runtimeuse/package-lock.json
+++ b/packages/runtimeuse/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runtimeuse",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runtimeuse",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "FSL",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.73",

--- a/packages/runtimeuse/package.json
+++ b/packages/runtimeuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimeuse",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "AI agent runtime with WebSocket protocol, artifact handling, and secret management",
   "license": "FSL",
   "type": "module",

--- a/packages/runtimeuse/src/session.test.ts
+++ b/packages/runtimeuse/src/session.test.ts
@@ -129,7 +129,7 @@ const INVOCATION_MSG = {
   system_prompt: "You are a tester",
   user_prompt: "Test the login flow",
   secrets_to_redact: ["secret123"],
-  artifacts_dir: "/tmp/artifacts",
+  artifacts_dirs: ["/tmp/artifacts"],
   output_format_json_schema_str: JSON.stringify({
     type: "json_schema",
     schema: { type: "object" },
@@ -507,18 +507,67 @@ describe("WebSocketSession", () => {
       );
     });
 
-    it("registers each request's artifacts_dir on the shared watcher", async () => {
+    it("registers each request's artifacts_dirs on the shared watcher", async () => {
       const { session, ws } = createSession();
       const done = session.run();
 
-      sendMessage(ws, { ...INVOCATION_MSG, artifacts_dir: "/tmp/first" });
+      sendMessage(ws, { ...INVOCATION_MSG, artifacts_dirs: ["/tmp/first"] });
       await waitForTerminal(ws, 1);
-      sendMessage(ws, { ...INVOCATION_MSG, artifacts_dir: "/tmp/second" });
+      sendMessage(ws, { ...INVOCATION_MSG, artifacts_dirs: ["/tmp/second"] });
       await waitForTerminal(ws, 2);
       await endSession(ws, done);
 
       expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/first");
       expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/second");
+    });
+
+    it("registers every directory when a request lists multiple artifacts_dirs", async () => {
+      const { session, ws } = createSession();
+      const done = session.run();
+
+      sendMessage(ws, {
+        ...INVOCATION_MSG,
+        artifacts_dirs: ["/tmp/a", "/tmp/b", "/tmp/c"],
+      });
+      await waitForTerminal(ws);
+      await endSession(ws, done);
+
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/a");
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/b");
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/c");
+    });
+
+    it("still accepts the deprecated singular artifacts_dir field", async () => {
+      const { session, ws } = createSession();
+      const done = session.run();
+
+      const { artifacts_dirs: _omit, ...withoutPlural } = INVOCATION_MSG;
+      sendMessage(ws, { ...withoutPlural, artifacts_dir: "/tmp/legacy" });
+      await waitForTerminal(ws);
+      await endSession(ws, done);
+
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/legacy",
+      );
+    });
+
+    it("dedupes when both artifacts_dir and artifacts_dirs name the same path", async () => {
+      const { session, ws } = createSession();
+      const done = session.run();
+
+      sendMessage(ws, {
+        ...INVOCATION_MSG,
+        artifacts_dir: "/tmp/shared",
+        artifacts_dirs: ["/tmp/shared", "/tmp/extra"],
+      });
+      await waitForTerminal(ws);
+      await endSession(ws, done);
+
+      const sharedCalls = mockArtifactManager.addDirectory.mock.calls.filter(
+        (c) => c[0] === "/tmp/shared",
+      );
+      expect(sharedCalls).toHaveLength(1);
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/extra");
     });
   });
 

--- a/packages/runtimeuse/src/session.ts
+++ b/packages/runtimeuse/src/session.ts
@@ -146,9 +146,15 @@ export class WebSocketSession {
     this.config.uploadTracker.setLogger(this.logger);
     this.logger.log("Handling new request");
 
-    if (message.artifacts_dir) {
+    // Watched directories accumulate across requests on a persistent session:
+    // chokidar's awaitWriteFinish + async upload may flush files written near
+    // the end of one request well into the next, and we want to capture those.
+    const artifactDirs = this.collectArtifactDirs(message);
+    if (artifactDirs.length > 0) {
       this.ensureArtifactManager();
-      this.artifactManager!.addDirectory(message.artifacts_dir);
+      for (const dir of artifactDirs) {
+        this.artifactManager!.addDirectory(dir);
+      }
     }
 
     const runner = new InvocationRunner({
@@ -238,6 +244,22 @@ export class WebSocketSession {
       })();
     }
     return this.drainPromise;
+  }
+
+  private collectArtifactDirs(
+    message: InvocationMessage | CommandExecutionMessage,
+  ): string[] {
+    const dirs: string[] = [];
+    if (message.artifacts_dir) {
+      this.logger.warn(
+        "artifacts_dir is deprecated; use artifacts_dirs (string[]) instead.",
+      );
+      dirs.push(message.artifacts_dir);
+    }
+    if (message.artifacts_dirs) {
+      dirs.push(...message.artifacts_dirs);
+    }
+    return [...new Set(dirs)];
   }
 
   private ensureArtifactManager(): void {

--- a/packages/runtimeuse/src/types.ts
+++ b/packages/runtimeuse/src/types.ts
@@ -18,7 +18,9 @@ interface InvocationMessage {
   secrets_to_redact: string[];
   output_format_json_schema_str?: string;
   model: string;
+  /** @deprecated Use `artifacts_dirs`. Accepted for backwards compatibility. */
   artifacts_dir?: string;
+  artifacts_dirs?: string[];
   pre_agent_invocation_commands?: Command[];
   post_agent_invocation_commands?: Command[];
   pre_agent_downloadables?: RuntimeEnvironmentDownloadable[];
@@ -29,7 +31,9 @@ interface CommandExecutionMessage {
   source_id?: string;
   secrets_to_redact: string[];
   commands: Command[];
+  /** @deprecated Use `artifacts_dirs`. Accepted for backwards compatibility. */
   artifacts_dir?: string;
+  artifacts_dirs?: string[];
   pre_execution_downloadables?: RuntimeEnvironmentDownloadable[];
 }
 


### PR DESCRIPTION
## Summary

- Add `artifacts_dirs: string[]` to `InvocationMessage` and `CommandExecutionMessage` so a single invocation/command-execution can declare multiple artifact directories. The underlying `ArtifactManager` already supported multiple watched directories per session — this change just opens up the wire.
- TS runtime accepts **both** fields during a transition: the legacy singular `artifacts_dir` is kept and marked `@deprecated`, with a one-line `logger.warn` when it's used. `collectArtifactDirs()` in `session.ts` merges and dedupes.
- Python client cuts over cleanly to `artifacts_dirs: list[str] | None` on `QueryOptions` and `ExecuteCommandsOptions`. Pairing rule with `on_artifact_upload_request` is preserved (empty list = `None`). The duplicated `__post_init__` validation across the two dataclasses is extracted to `_validate_artifact_pairing`.
- Docs updated: `python-client.mdx`, both package READMEs.

## Test plan

- [x] `vitest run` in `packages/runtimeuse` — 149 tests pass, including 4 new tests covering multi-dir, the deprecated singular field, and dedup of overlapping fields.
- [x] `pytest test/test_client.py` in `packages/runtimeuse-client-python` — 58 tests pass, including new tests asserting that `artifacts_dirs` is forwarded to both `invocation_message` and `command_execution_message` and that `artifacts_dir` is no longer sent.
- [x] `pytest test/e2e/` — 37 tests pass, including a new `test_multiple_artifacts_dirs_in_single_invocation` that has a pre-agent command write to one directory and the agent write to another within a single invocation, then asserts both files upload.
- [ ] Run advanced LLM tests against live providers if you want to verify there too — kwarg renamed, no behavioral change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the cross-language wire format for artifact uploads and changes the Python public API from `artifacts_dir` to `artifacts_dirs`, so mismatched client/runtime versions could break artifact watching despite runtime backward compatibility.
> 
> **Overview**
> Adds multi-directory artifact watching by introducing `artifacts_dirs` on both `InvocationMessage` and `CommandExecutionMessage`, and updating the TypeScript runtime to merge/dedupe `artifacts_dirs` with the deprecated legacy `artifacts_dir` (emitting a warning when the old field is used).
> 
> Updates the Python client API to replace `artifacts_dir` with `artifacts_dirs: list[str] | None` for `QueryOptions`/`ExecuteCommandsOptions`, forwards the new field on the wire, and refactors the “artifacts + callback must be paired” validation into a shared helper (treating `[]` as disabled). Docs and tests are updated, including new coverage for multi-dir uploads and deprecated-field compatibility; versions are bumped to `0.14.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4af077bb5137317560624a4e50cd261646c724c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->