### PR TITLE
Accept inline artifact-ignore patterns via message protocol

### DIFF
--- a/packages/runtimeuse-client-python/pyproject.toml
+++ b/packages/runtimeuse-client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "runtimeuse-client"
-version = "0.14.2"
+version = "0.15.0"
 description = "Client library for AI agent runtime communication over WebSocket"
 readme = "README.md"
 license = {"text" = "FSL"}

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/client.py
@@ -43,6 +43,7 @@ def _build_invocation(prompt: str, options: QueryOptions) -> InvocationMessage:
         agent_env=options.agent_env,
         secrets_to_redact=options.secrets_to_redact,
         artifacts_dirs=options.artifacts_dirs or None,
+        artifacts_ignore_content=options.artifacts_ignore_content,
         pre_agent_invocation_commands=options.pre_agent_invocation_commands,
         post_agent_invocation_commands=options.post_agent_invocation_commands,
         pre_agent_downloadables=options.pre_agent_downloadables,
@@ -58,6 +59,7 @@ def _build_command_execution(
         secrets_to_redact=options.secrets_to_redact,
         commands=commands,
         artifacts_dirs=options.artifacts_dirs or None,
+        artifacts_ignore_content=options.artifacts_ignore_content,
         pre_execution_downloadables=options.pre_execution_downloadables,
     )
 

--- a/packages/runtimeuse-client-python/src/runtimeuse_client/types.py
+++ b/packages/runtimeuse-client-python/src/runtimeuse_client/types.py
@@ -40,6 +40,7 @@ class InvocationMessage(BaseModel):
     output_format_json_schema_str: str | None = None
     secrets_to_redact: list[str] = Field(default_factory=list)
     artifacts_dirs: list[str] | None = None
+    artifacts_ignore_content: str | None = None
     pre_agent_invocation_commands: list[CommandInterface] | None = None
     post_agent_invocation_commands: list[CommandInterface] | None = None
     model: str
@@ -140,6 +141,7 @@ class CommandExecutionMessage(BaseModel):
     secrets_to_redact: list[str] = Field(default_factory=list)
     commands: list[CommandInterface]
     artifacts_dirs: list[str] | None = None
+    artifacts_ignore_content: str | None = None
     pre_execution_downloadables: (
         list[RuntimeEnvironmentDownloadableInterface] | None
     ) = None
@@ -213,6 +215,12 @@ class QueryOptions:
     #: Each directory is watched independently and may carry its own
     #: ``.artifactignore``. An empty list is treated the same as ``None``.
     artifacts_dirs: list[str] | None = None
+    #: Gitignore-format text applied as the ignore patterns for every directory
+    #: in ``artifacts_dirs``. When set, takes precedence over any
+    #: ``.artifactignore`` file present at the watched directory in the runtime
+    #: environment. Use this when the watched directory may not exist on disk
+    #: at the time the runtime starts watching it.
+    artifacts_ignore_content: str | None = None
     #: Commands to run in the runtime environment before the agent starts.
     pre_agent_invocation_commands: list[CommandInterface] | None = None
     #: Commands to run in the runtime environment after the agent finishes.
@@ -255,6 +263,12 @@ class ExecuteCommandsOptions:
     #: Each directory is watched independently and may carry its own
     #: ``.artifactignore``. An empty list is treated the same as ``None``.
     artifacts_dirs: list[str] | None = None
+    #: Gitignore-format text applied as the ignore patterns for every directory
+    #: in ``artifacts_dirs``. When set, takes precedence over any
+    #: ``.artifactignore`` file present at the watched directory in the runtime
+    #: environment. Use this when the watched directory may not exist on disk
+    #: at the time the runtime starts watching it.
+    artifacts_ignore_content: str | None = None
     #: Files to download into the runtime environment before commands run.
     pre_execution_downloadables: (
         list[RuntimeEnvironmentDownloadableInterface] | None

--- a/packages/runtimeuse-client-python/test/test_client.py
+++ b/packages/runtimeuse-client-python/test/test_client.py
@@ -360,6 +360,59 @@ class TestArtifactUpload:
             options=query_options,
         )
 
+    @pytest.mark.asyncio
+    async def test_artifacts_ignore_content_forwarded_to_invocation(
+        self, fake_transport, make_query_options
+    ):
+        transport, client = fake_transport([TEXT_RESULT_MSG])
+
+        async def _on_artifact(_req):
+            return ArtifactUploadResult(
+                presigned_url="https://s3.example.com/x", content_type="text/plain"
+            )
+
+        await client.query(
+            prompt=DEFAULT_PROMPT,
+            options=make_query_options(
+                artifacts_dirs=["/tmp/artifacts"],
+                artifacts_ignore_content="*.log\nnode_modules/\n",
+                on_artifact_upload_request=_on_artifact,
+            ),
+        )
+
+        invocation_msgs = [
+            m for m in transport.sent if m.get("message_type") == "invocation_message"
+        ]
+        assert len(invocation_msgs) == 1
+        assert (
+            invocation_msgs[0]["artifacts_ignore_content"]
+            == "*.log\nnode_modules/\n"
+        )
+
+    @pytest.mark.asyncio
+    async def test_artifacts_ignore_content_defaults_to_none(
+        self, fake_transport, make_query_options
+    ):
+        transport, client = fake_transport([TEXT_RESULT_MSG])
+
+        async def _on_artifact(_req):
+            return ArtifactUploadResult(
+                presigned_url="https://s3.example.com/x", content_type="text/plain"
+            )
+
+        await client.query(
+            prompt=DEFAULT_PROMPT,
+            options=make_query_options(
+                artifacts_dirs=["/tmp/artifacts"],
+                on_artifact_upload_request=_on_artifact,
+            ),
+        )
+
+        invocation_msgs = [
+            m for m in transport.sent if m.get("message_type") == "invocation_message"
+        ]
+        assert invocation_msgs[0]["artifacts_ignore_content"] is None
+
 
 # ---------------------------------------------------------------------------
 # Cancellation
@@ -1084,6 +1137,34 @@ class TestExecuteCommands:
         assert len(cmd_msgs) == 1
         assert cmd_msgs[0]["artifacts_dirs"] == ["/tmp/one", "/tmp/two"]
         assert "artifacts_dir" not in cmd_msgs[0]
+
+    @pytest.mark.asyncio
+    async def test_artifacts_ignore_content_forwarded_to_command_execution(
+        self, fake_transport, make_execute_commands_options
+    ):
+        transport, client = fake_transport([COMMAND_RESULT_MSG])
+
+        async def _on_artifact(_req):
+            return ArtifactUploadResult(
+                presigned_url="https://s3.example.com/x", content_type="text/plain"
+            )
+
+        await client.execute_commands(
+            commands=[CommandInterface(command="echo hello")],
+            options=make_execute_commands_options(
+                artifacts_dirs=["/tmp/artifacts"],
+                artifacts_ignore_content="*.tmp\n",
+                on_artifact_upload_request=_on_artifact,
+            ),
+        )
+
+        cmd_msgs = [
+            m
+            for m in transport.sent
+            if m.get("message_type") == "command_execution_message"
+        ]
+        assert len(cmd_msgs) == 1
+        assert cmd_msgs[0]["artifacts_ignore_content"] == "*.tmp\n"
 
     @pytest.mark.asyncio
     async def test_command_env_forwarded(

--- a/packages/runtimeuse-client-python/uv.lock
+++ b/packages/runtimeuse-client-python/uv.lock
@@ -1618,7 +1618,7 @@ wheels = [
 
 [[package]]
 name = "runtimeuse-client"
-version = "0.14.2"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/packages/runtimeuse/package-lock.json
+++ b/packages/runtimeuse/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runtimeuse",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runtimeuse",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "license": "FSL",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.73",

--- a/packages/runtimeuse/package.json
+++ b/packages/runtimeuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimeuse",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "AI agent runtime with WebSocket protocol, artifact handling, and secret management",
   "license": "FSL",
   "type": "module",

--- a/packages/runtimeuse/src/artifact-manager.test.ts
+++ b/packages/runtimeuse/src/artifact-manager.test.ts
@@ -31,14 +31,26 @@ import fs from "fs";
 import chokidar from "chokidar";
 import {
   ArtifactManager,
+  type AddDirectoryOptions,
   type ArtifactManagerConfig,
 } from "./artifact-manager.js";
 import { UploadTracker } from "./upload-tracker.js";
 import { uploadFile } from "./storage.js";
+import type { Logger } from "./logger.js";
+
+function makeLogger(): Logger {
+  return {
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
 
 function createManager(
   overrides: Partial<ArtifactManagerConfig> = {},
   artifactsDir: string | null = "/tmp/artifacts",
+  addOptions: AddDirectoryOptions = {},
 ) {
   const send = vi.fn();
   const uploadTracker = new UploadTracker();
@@ -47,9 +59,11 @@ function createManager(
     send,
     ...overrides,
   };
+  const logger = makeLogger();
   const manager = new ArtifactManager(config);
-  if (artifactsDir) manager.addDirectory(artifactsDir);
-  return { manager, send, uploadTracker };
+  manager.setLogger(logger);
+  if (artifactsDir) manager.addDirectory(artifactsDir, addOptions);
+  return { manager, send, uploadTracker, logger };
 }
 
 function getHandler(event: string) {
@@ -319,6 +333,86 @@ describe("ArtifactManager", () => {
       const { send } = createManager();
       getHandler("add")("/tmp/artifacts/.artifactignore", fileStats());
       expect(send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ignoreContent option", () => {
+    it("applies inline ignore patterns from ignoreContent", () => {
+      const { send } = createManager({}, "/tmp/artifacts", {
+        ignoreContent: "*.log\n",
+      });
+      getHandler("add")("/tmp/artifacts/debug.log", fileStats());
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it("does not read .artifactignore from disk when ignoreContent is provided", () => {
+      createManager({}, "/tmp/artifacts", { ignoreContent: "*.log\n" });
+      expect(fs.existsSync).not.toHaveBeenCalled();
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it("ignoreContent wins over an inline blob even with a .artifactignore on disk", () => {
+      const { send } = createManager({}, "/tmp/artifacts", {
+        ignoreContent: "*.log\n",
+      });
+
+      // The inline blob declares only *.log, so a file matching the on-disk
+      // .artifactignore (*.png) should still be uploaded.
+      getHandler("add")("/tmp/artifacts/screenshot.png", fileStats());
+      expect(send).toHaveBeenCalledWith(
+        expect.objectContaining({ filename: "screenshot.png" }),
+      );
+
+      send.mockClear();
+      // *.log SHOULD be ignored per the inline blob.
+      getHandler("add")("/tmp/artifacts/debug.log", fileStats());
+      expect(send).not.toHaveBeenCalled();
+
+      // The inline blob path must not touch the filesystem at all.
+      expect(fs.existsSync).not.toHaveBeenCalled();
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it("file event for .artifactignore does not overwrite the inline blob", () => {
+      const { send } = createManager({}, "/tmp/artifacts", {
+        ignoreContent: "*.log\n",
+      });
+
+      // A .artifactignore file event would, without the pin, replace the
+      // patterns with whatever the file contains. The pin should short-circuit
+      // before the runtime even checks the filesystem.
+      getHandler("change")(
+        "/tmp/artifacts/.artifactignore",
+        fileStats(),
+      );
+
+      // The inline blob is still in effect, so *.log is still ignored.
+      getHandler("add")("/tmp/artifacts/debug.log", fileStats());
+      expect(send).not.toHaveBeenCalled();
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it("warns when neither ignoreContent nor a .artifactignore file is provided", () => {
+      const { logger } = createManager();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "No artifact ignore patterns provided for /tmp/artifacts",
+        ),
+      );
+    });
+
+    it("does not warn when an .artifactignore file is found", () => {
+      vi.mocked(fs.existsSync).mockReturnValueOnce(true);
+      vi.mocked(fs.readFileSync).mockReturnValueOnce("*.log\n");
+      const { logger } = createManager();
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("does not warn when ignoreContent is provided", () => {
+      const { logger } = createManager({}, "/tmp/artifacts", {
+        ignoreContent: "*.log\n",
+      });
+      expect(logger.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/runtimeuse/src/artifact-manager.test.ts
+++ b/packages/runtimeuse/src/artifact-manager.test.ts
@@ -414,5 +414,20 @@ describe("ArtifactManager", () => {
       });
       expect(logger.warn).not.toHaveBeenCalled();
     });
+
+    it("treats ignoreContent: null the same as omitted", () => {
+      // The session forwards `message.artifacts_ignore_content` straight into
+      // options, and Python clients serialize unset optional fields as JSON
+      // null. The manager must not pass that null into the ignore parser.
+      vi.mocked(fs.existsSync).mockReturnValueOnce(true);
+      vi.mocked(fs.readFileSync).mockReturnValueOnce("*.log\n");
+
+      const { send } = createManager({}, "/tmp/artifacts", {
+        ignoreContent: null as unknown as string | undefined,
+      });
+      // Falls back to the on-disk .artifactignore loaded above.
+      getHandler("add")("/tmp/artifacts/debug.log", fileStats());
+      expect(send).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/runtimeuse/src/artifact-manager.ts
+++ b/packages/runtimeuse/src/artifact-manager.ts
@@ -16,13 +16,30 @@ export interface ArtifactManagerConfig {
   send: (message: ArtifactUploadRequestMessage) => void;
 }
 
+export interface AddDirectoryOptions {
+  /**
+   * Gitignore-format text used as the ignore patterns for this directory.
+   * When provided, takes precedence over any `.artifactignore` file at
+   * `<dir>/.artifactignore` and pins the source so subsequent on-disk file
+   * events do not overwrite the in-memory patterns.
+   */
+  ignoreContent?: string;
+}
+
+type IgnoreSource = "content" | "file" | "default";
+
+interface WatchedDir {
+  ig: Ignore;
+  source: IgnoreSource;
+}
+
 export class ArtifactManager {
   private readonly watcher: ReturnType<typeof chokidar.watch>;
   private readonly pendingRequests = new Map<
     string,
     { promise: Promise<void>; resolve: () => void }
   >();
-  private readonly watchedDirs = new Map<string, Ignore>();
+  private readonly watchedDirs = new Map<string, WatchedDir>();
   private readonly uploadTracker: UploadTracker;
   private readonly send: (message: ArtifactUploadRequestMessage) => void;
   private logger: Logger = defaultLogger;
@@ -46,22 +63,42 @@ export class ArtifactManager {
    * requests in the same session — repeat calls for the same directory are
    * no-ops. The watcher stays alive until {@link stopWatching} is called at
    * session close.
+   *
+   * Ignore-pattern resolution order:
+   *   1. `options.ignoreContent` if provided (pinned — file events do not
+   *      overwrite it).
+   *   2. `<dir>/.artifactignore` on disk if present.
+   *   3. {@link DEFAULT_ARTIFACT_IGNORE}, with a warning logged so the
+   *      fallback is visible.
    */
-  addDirectory(dir: string): void {
+  addDirectory(dir: string, options: AddDirectoryOptions = {}): void {
     if (this.watchedDirs.has(dir)) return;
 
     fs.mkdirSync(dir, { recursive: true });
 
     const ig = ignore();
-    const ignorePath = path.join(dir, ".artifactignore");
-    if (fs.existsSync(ignorePath)) {
-      ig.add(fs.readFileSync(ignorePath, "utf-8"));
-      this.logger.log(`Loaded .artifactignore from ${ignorePath}`);
+    let source: IgnoreSource;
+
+    if (options.ignoreContent !== undefined) {
+      ig.add(options.ignoreContent);
+      this.logger.log(`Loaded ignore patterns from message for ${dir}`);
+      source = "content";
     } else {
-      ig.add(DEFAULT_ARTIFACT_IGNORE);
+      const ignorePath = path.join(dir, ".artifactignore");
+      if (fs.existsSync(ignorePath)) {
+        ig.add(fs.readFileSync(ignorePath, "utf-8"));
+        this.logger.log(`Loaded .artifactignore from ${ignorePath}`);
+        source = "file";
+      } else {
+        ig.add(DEFAULT_ARTIFACT_IGNORE);
+        this.logger.warn(
+          `No artifact ignore patterns provided for ${dir}; using built-in default`,
+        );
+        source = "default";
+      }
     }
 
-    this.watchedDirs.set(dir, ig);
+    this.watchedDirs.set(dir, { ig, source });
     this.watcher.add(dir);
   }
 
@@ -154,9 +191,9 @@ export class ArtifactManager {
       return;
     }
 
-    const ig = this.watchedDirs.get(owningDir);
+    const watched = this.watchedDirs.get(owningDir);
     const relativePath = path.relative(owningDir, filePath);
-    if (ig && ig.ignores(relativePath)) {
+    if (watched && watched.ig.ignores(relativePath)) {
       if (this.loggingLevel === "debug") {
         this.logger.debug(`Skipping ignored artifact: ${relativePath}`);
       }
@@ -167,15 +204,21 @@ export class ArtifactManager {
   }
 
   private reloadIgnorePatterns(dir: string): void {
+    const existing = this.watchedDirs.get(dir);
+    // A message-supplied ignore blob is the authoritative source for that
+    // directory; on-disk file events must not silently override it.
+    if (existing?.source === "content") return;
+
     const ig = ignore();
     const ignorePath = path.join(dir, ".artifactignore");
     if (fs.existsSync(ignorePath)) {
       ig.add(fs.readFileSync(ignorePath, "utf-8"));
       this.logger.log(`Reloaded .artifactignore from ${ignorePath}`);
+      this.watchedDirs.set(dir, { ig, source: "file" });
     } else {
       ig.add(DEFAULT_ARTIFACT_IGNORE);
+      this.watchedDirs.set(dir, { ig, source: "default" });
     }
-    this.watchedDirs.set(dir, ig);
   }
 
   private requestUpload(filePath: string): void {

--- a/packages/runtimeuse/src/artifact-manager.ts
+++ b/packages/runtimeuse/src/artifact-manager.ts
@@ -79,7 +79,7 @@ export class ArtifactManager {
     const ig = ignore();
     let source: IgnoreSource;
 
-    if (options.ignoreContent !== undefined) {
+    if (options.ignoreContent != null) {
       ig.add(options.ignoreContent);
       this.logger.log(`Loaded ignore patterns from message for ${dir}`);
       source = "content";

--- a/packages/runtimeuse/src/session.test.ts
+++ b/packages/runtimeuse/src/session.test.ts
@@ -517,8 +517,14 @@ describe("WebSocketSession", () => {
       await waitForTerminal(ws, 2);
       await endSession(ws, done);
 
-      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/first");
-      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/second");
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/first",
+        expect.any(Object),
+      );
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/second",
+        expect.any(Object),
+      );
     });
 
     it("registers every directory when a request lists multiple artifacts_dirs", async () => {
@@ -532,9 +538,18 @@ describe("WebSocketSession", () => {
       await waitForTerminal(ws);
       await endSession(ws, done);
 
-      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/a");
-      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/b");
-      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/c");
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/a",
+        expect.any(Object),
+      );
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/b",
+        expect.any(Object),
+      );
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/c",
+        expect.any(Object),
+      );
     });
 
     it("still accepts the deprecated singular artifacts_dir field", async () => {
@@ -548,6 +563,7 @@ describe("WebSocketSession", () => {
 
       expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
         "/tmp/legacy",
+        expect.any(Object),
       );
     });
 
@@ -567,7 +583,69 @@ describe("WebSocketSession", () => {
         (c) => c[0] === "/tmp/shared",
       );
       expect(sharedCalls).toHaveLength(1);
-      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/extra");
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/extra",
+        expect.any(Object),
+      );
+    });
+
+    it("forwards artifacts_ignore_content to every addDirectory call", async () => {
+      const { session, ws } = createSession();
+      const done = session.run();
+
+      sendMessage(ws, {
+        ...INVOCATION_MSG,
+        artifacts_dirs: ["/tmp/a", "/tmp/b"],
+        artifacts_ignore_content: "*.log\nnode_modules/\n",
+      });
+      await waitForTerminal(ws);
+      await endSession(ws, done);
+
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/a", {
+        ignoreContent: "*.log\nnode_modules/\n",
+      });
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith("/tmp/b", {
+        ignoreContent: "*.log\nnode_modules/\n",
+      });
+    });
+
+    it("passes empty options when artifacts_ignore_content is omitted", async () => {
+      const { session, ws } = createSession();
+      const done = session.run();
+
+      sendMessage(ws, {
+        ...INVOCATION_MSG,
+        artifacts_dirs: ["/tmp/only"],
+      });
+      await waitForTerminal(ws);
+      await endSession(ws, done);
+
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/only",
+        {},
+      );
+    });
+
+    it("forwards artifacts_ignore_content from a command_execution_message", async () => {
+      mockCommandExecute.mockResolvedValueOnce({ exitCode: 0 });
+      const { session, ws } = createSession();
+      const done = session.run();
+
+      sendMessage(ws, {
+        message_type: "command_execution_message",
+        source_id: "cmd-test",
+        secrets_to_redact: [],
+        commands: [{ command: "echo hi" }],
+        artifacts_dirs: ["/tmp/cmd-artifacts"],
+        artifacts_ignore_content: "*.tmp\n",
+      });
+      await waitForTerminal(ws);
+      await endSession(ws, done);
+
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/cmd-artifacts",
+        { ignoreContent: "*.tmp\n" },
+      );
     });
   });
 

--- a/packages/runtimeuse/src/session.test.ts
+++ b/packages/runtimeuse/src/session.test.ts
@@ -626,6 +626,27 @@ describe("WebSocketSession", () => {
       );
     });
 
+    it("treats artifacts_ignore_content: null as omitted (cross-language wire format)", async () => {
+      // Other-language clients (e.g. Python's pydantic .model_dump) serialize
+      // an unset Optional field as JSON null rather than omitting it. The
+      // runtime must accept that without crashing the ignore parser.
+      const { session, ws } = createSession();
+      const done = session.run();
+
+      sendMessage(ws, {
+        ...INVOCATION_MSG,
+        artifacts_dirs: ["/tmp/with-null"],
+        artifacts_ignore_content: null,
+      });
+      await waitForTerminal(ws);
+      await endSession(ws, done);
+
+      expect(mockArtifactManager.addDirectory).toHaveBeenCalledWith(
+        "/tmp/with-null",
+        {},
+      );
+    });
+
     it("forwards artifacts_ignore_content from a command_execution_message", async () => {
       mockCommandExecute.mockResolvedValueOnce({ exitCode: 0 });
       const { session, ws } = createSession();

--- a/packages/runtimeuse/src/session.ts
+++ b/packages/runtimeuse/src/session.ts
@@ -1,7 +1,10 @@
 import { WebSocket } from "ws";
 
 import type { AgentHandler } from "./agent-handler.js";
-import { ArtifactManager } from "./artifact-manager.js";
+import {
+  ArtifactManager,
+  type AddDirectoryOptions,
+} from "./artifact-manager.js";
 import type { UploadTracker } from "./upload-tracker.js";
 import type {
   InvocationMessage,
@@ -149,11 +152,11 @@ export class WebSocketSession {
     // Watched directories accumulate across requests on a persistent session:
     // chokidar's awaitWriteFinish + async upload may flush files written near
     // the end of one request well into the next, and we want to capture those.
-    const artifactDirs = this.collectArtifactDirs(message);
-    if (artifactDirs.length > 0) {
+    const artifactDirSpecs = this.collectArtifactDirSpecs(message);
+    if (artifactDirSpecs.length > 0) {
       this.ensureArtifactManager();
-      for (const dir of artifactDirs) {
-        this.artifactManager!.addDirectory(dir);
+      for (const spec of artifactDirSpecs) {
+        this.artifactManager!.addDirectory(spec.dir, spec.options);
       }
     }
 
@@ -246,9 +249,9 @@ export class WebSocketSession {
     return this.drainPromise;
   }
 
-  private collectArtifactDirs(
+  private collectArtifactDirSpecs(
     message: InvocationMessage | CommandExecutionMessage,
-  ): string[] {
+  ): Array<{ dir: string; options: AddDirectoryOptions }> {
     const dirs: string[] = [];
     if (message.artifacts_dir) {
       this.logger.warn(
@@ -259,7 +262,10 @@ export class WebSocketSession {
     if (message.artifacts_dirs) {
       dirs.push(...message.artifacts_dirs);
     }
-    return [...new Set(dirs)];
+    const ignoreContent = message.artifacts_ignore_content;
+    const options: AddDirectoryOptions =
+      ignoreContent !== undefined ? { ignoreContent } : {};
+    return [...new Set(dirs)].map((dir) => ({ dir, options }));
   }
 
   private ensureArtifactManager(): void {

--- a/packages/runtimeuse/src/session.ts
+++ b/packages/runtimeuse/src/session.ts
@@ -262,9 +262,12 @@ export class WebSocketSession {
     if (message.artifacts_dirs) {
       dirs.push(...message.artifacts_dirs);
     }
+    // Treat both `undefined` and `null` as "not provided". Other-language
+    // clients (e.g. Python) may serialize an unset optional field as JSON
+    // null rather than omitting it.
     const ignoreContent = message.artifacts_ignore_content;
     const options: AddDirectoryOptions =
-      ignoreContent !== undefined ? { ignoreContent } : {};
+      ignoreContent != null ? { ignoreContent } : {};
     return [...new Set(dirs)].map((dir) => ({ dir, options }));
   }
 

--- a/packages/runtimeuse/src/types.ts
+++ b/packages/runtimeuse/src/types.ts
@@ -21,6 +21,13 @@ interface InvocationMessage {
   /** @deprecated Use `artifacts_dirs`. Accepted for backwards compatibility. */
   artifacts_dir?: string;
   artifacts_dirs?: string[];
+  /**
+   * Gitignore-format text applied as the ignore patterns for every directory
+   * in `artifacts_dirs` for this message. When set, takes precedence over any
+   * `.artifactignore` file at the watched directory. The runtime never reads
+   * this from the filesystem — the consumer is responsible for sourcing it.
+   */
+  artifacts_ignore_content?: string;
   pre_agent_invocation_commands?: Command[];
   post_agent_invocation_commands?: Command[];
   pre_agent_downloadables?: RuntimeEnvironmentDownloadable[];
@@ -34,6 +41,13 @@ interface CommandExecutionMessage {
   /** @deprecated Use `artifacts_dirs`. Accepted for backwards compatibility. */
   artifacts_dir?: string;
   artifacts_dirs?: string[];
+  /**
+   * Gitignore-format text applied as the ignore patterns for every directory
+   * in `artifacts_dirs` for this message. When set, takes precedence over any
+   * `.artifactignore` file at the watched directory. The runtime never reads
+   * this from the filesystem — the consumer is responsible for sourcing it.
+   */
+  artifacts_ignore_content?: string;
   pre_execution_downloadables?: RuntimeEnvironmentDownloadable[];
 }
 


### PR DESCRIPTION
## Summary
- Add optional `artifacts_ignore_content?: string` to `InvocationMessage` and `CommandExecutionMessage` so consumers can carry gitignore-format ignore patterns through the wire instead of relying on a `.artifactignore` file at the watched directory.
- `ArtifactManager.addDirectory(dir, options?)` now resolves patterns in this order:
  1. `options.ignoreContent` if provided (pinned — runtime file events for `.artifactignore` no longer overwrite it).
  2. `<dir>/.artifactignore` on disk (existing behavior, kept for back-compat).
  3. `DEFAULT_ARTIFACT_IGNORE`, with a `logger.warn` so the fallback is visible in operator logs instead of silently masking a misconfig.
- Python client: new `artifacts_ignore_content` field on `QueryOptions` and `ExecuteCommandsOptions`, plumbed through both invocation and command-execution message builders.
- Bump both packages to 0.15.0.

## Why
Consumers whose watched directory is created (or wiped) by the runtime environment after image build time can't ship a `.artifactignore` reliably — by the time the runtime starts watching the directory, any file copied at build time may be gone. Routing the patterns through the message protocol removes that filesystem-coupling. Promoting the previously-silent default fallback to a `warn` makes future regressions of this kind visible immediately.

## Test plan
- [x] `npm run typecheck` (clean)
- [x] `npm test` — 159/159 vitest tests pass, including new coverage for: inline-blob match/skip, blob-vs-file precedence, file events not overwriting the inline blob, the new `warn` on the default fallback, and session forwarding of `artifacts_ignore_content` to every `addDirectory` call (invocation + command-execution).
- [x] `uv run pytest test/test_client.py` — 61/61 pass, including new round-trip tests for `artifacts_ignore_content` on both `query` and `execute_commands`.
- [ ] Existing-consumer back-compat: a message with only `artifacts_dirs` (no `artifacts_ignore_content`) and a `.artifactignore` at the watched dir continues to load the file (covered by existing tests, which still pass).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the artifact-watching/ignore-path behavior and message schema, which could impact which files are uploaded and how existing `.artifactignore` setups behave if edge cases were missed.
> 
> **Overview**
> Adds optional `artifacts_ignore_content` to invocation and command-execution messages so clients can supply gitignore-style artifact ignore rules over the wire instead of relying on an on-disk `.artifactignore`.
> 
> Updates the runtime `ArtifactManager` to accept per-directory `ignoreContent`, pinning in-memory patterns so `.artifactignore` file events don’t overwrite them, and emits a `warn` when falling back to the built-in default ignore rules. The session layer now forwards `artifacts_ignore_content` (treating `null` as omitted) to every `addDirectory` call, and the Python client plumbs the new option through `QueryOptions`/`ExecuteCommandsOptions` with added tests.
> 
> Bumps `runtimeuse` and `runtimeuse-client` versions to `0.15.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81870653cb14217f2bf117d9f3ef8a06801c27b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->