### PR TITLE
Honor configured logger across the request lifecycle

### DIFF
--- a/packages/runtimeuse-client-python/pyproject.toml
+++ b/packages/runtimeuse-client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "runtimeuse-client"
-version = "0.15.0"
+version = "0.15.1"
 description = "Client library for AI agent runtime communication over WebSocket"
 readme = "README.md"
 license = {"text" = "FSL"}

--- a/packages/runtimeuse-client-python/uv.lock
+++ b/packages/runtimeuse-client-python/uv.lock
@@ -1618,7 +1618,7 @@ wheels = [
 
 [[package]]
 name = "runtimeuse-client"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/packages/runtimeuse/package-lock.json
+++ b/packages/runtimeuse/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runtimeuse",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runtimeuse",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "FSL",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.73",

--- a/packages/runtimeuse/package.json
+++ b/packages/runtimeuse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimeuse",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "AI agent runtime with WebSocket protocol, artifact handling, and secret management",
   "license": "FSL",
   "type": "module",

--- a/packages/runtimeuse/src/index.ts
+++ b/packages/runtimeuse/src/index.ts
@@ -56,7 +56,12 @@ export type {
 
 // Utilities
 export { redactSecrets, sleep } from "./utils.js";
-export { createLogger, createRedactingLogger, defaultLogger } from "./logger.js";
+export {
+  createLogger,
+  createPrefixedLogger,
+  createRedactingLogger,
+  defaultLogger,
+} from "./logger.js";
 export type { Logger } from "./logger.js";
 
 // Constants

--- a/packages/runtimeuse/src/logger.ts
+++ b/packages/runtimeuse/src/logger.ts
@@ -7,14 +7,18 @@ export interface Logger {
   debug(...args: unknown[]): void;
 }
 
-export function createLogger(sourceId: string): Logger {
-  const prefix = `[${sourceId}]`;
+export function createPrefixedLogger(inner: Logger, prefix: string): Logger {
+  const tag = `[${prefix}]`;
   return {
-    log: (...args: unknown[]) => console.log(prefix, ...args),
-    warn: (...args: unknown[]) => console.warn(prefix, ...args),
-    error: (...args: unknown[]) => console.error(prefix, ...args),
-    debug: (...args: unknown[]) => console.debug(prefix, ...args),
+    log: (...args: unknown[]) => inner.log(tag, ...args),
+    warn: (...args: unknown[]) => inner.warn(tag, ...args),
+    error: (...args: unknown[]) => inner.error(tag, ...args),
+    debug: (...args: unknown[]) => inner.debug(tag, ...args),
   };
+}
+
+export function createLogger(sourceId: string): Logger {
+  return createPrefixedLogger(defaultLogger, sourceId);
 }
 
 export function createRedactingLogger(

--- a/packages/runtimeuse/src/session.test.ts
+++ b/packages/runtimeuse/src/session.test.ts
@@ -296,6 +296,52 @@ describe("WebSocketSession", () => {
     });
   });
 
+  describe("logger", () => {
+    it("routes per-request logs through the configured logger", async () => {
+      const logger = {
+        log: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+
+      const { session, ws } = createSession({ logger });
+      const done = session.run();
+      sendMessage(ws, INVOCATION_MSG);
+      await waitForTerminal(ws);
+      await endSession(ws, done);
+
+      const logged = logger.log.mock.calls.map((c) => c.join(" "));
+      expect(logged.some((l) => l.includes("[test-source-id] Handling new request"))).toBe(true);
+    });
+
+    it("redacts secrets when routing through the configured logger", async () => {
+      const logger = {
+        log: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+
+      mockHandlerRun.mockImplementation(async (invocation) => {
+        invocation.logger.log("leak: secret123");
+        return { type: "text", text: "ok" } as AgentResult;
+      });
+
+      const { session, ws } = createSession({ logger });
+      const done = session.run();
+      sendMessage(ws, INVOCATION_MSG);
+      await waitForTerminal(ws);
+      await endSession(ws, done);
+
+      const logged = logger.log.mock.calls.map((c) => c.join(" "));
+      expect(logged.some((l) => l.includes("leak: [REDACTED]"))).toBe(true);
+      for (const line of logged) {
+        expect(line).not.toContain("secret123");
+      }
+    });
+  });
+
   describe("heartbeats", () => {
     it("sends heartbeat messages while a request is in flight", async () => {
       let resolveAgent!: () => void;

--- a/packages/runtimeuse/src/session.ts
+++ b/packages/runtimeuse/src/session.ts
@@ -15,7 +15,7 @@ import type {
 import { getErrorMessage, serializeErrorMetadata } from "./error-utils.js";
 import { redactSecrets, sleep } from "./utils.js";
 import {
-  createLogger,
+  createPrefixedLogger,
   createRedactingLogger,
   defaultLogger,
   type Logger,
@@ -145,7 +145,11 @@ export class WebSocketSession {
 
     const sourceId = message.source_id ?? crypto.randomUUID();
     this.secrets = message.secrets_to_redact ?? [];
-    this.logger = createRedactingLogger(createLogger(sourceId), this.secrets);
+    const baseLogger = this.config.logger ?? defaultLogger;
+    this.logger = createRedactingLogger(
+      createPrefixedLogger(baseLogger, sourceId),
+      this.secrets,
+    );
     this.config.uploadTracker.setLogger(this.logger);
     this.logger.log("Handling new request");
 


### PR DESCRIPTION
## Summary

- `WebSocketSession.handleRequest` was replacing the configured logger with a fresh console-based one for every request, so a logger passed via `RuntimeUseServerConfig.logger` was bypassed for the entire request — including `UploadTracker`, `ArtifactManager`, `InvocationRunner`, the per-command logs, and the agent invocation's `logger`.
- The fix introduces `createPrefixedLogger(inner, prefix)` and wraps the configured logger (falling back to `defaultLogger`) with the source-id prefix and redaction layers, so the user-provided logger receives every per-request line.
- Bumps both packages to 0.15.1.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (151 passing, including two new `WebSocketSession > logger` tests verifying the configured logger receives prefixed, redacted log lines)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to logging plumbing (prefixing/redaction and routing to configured logger) plus version bumps, with new tests covering expected behavior.
> 
> **Overview**
> Ensures `WebSocketSession.handleRequest` routes all per-request logs through the user-provided `SessionConfig.logger` (falling back to `defaultLogger`) instead of always creating a fresh console logger.
> 
> Introduces `createPrefixedLogger(inner, prefix)` to apply the `source_id` tag while preserving the underlying logger, keeps secret redaction via `createRedactingLogger`, and adds tests verifying configured logger usage and redaction. Bumps package versions to `0.15.1` (Node and Python).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75a5933b9e4da164cf61b5a7e52f3c0c2fb383d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->